### PR TITLE
Improve CLI with absolute time feature

### DIFF
--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -7,11 +7,12 @@
 
 /*
   Controller coordinates a Model and a View.  It runs a simple CLI loop:
-    - “add” prompts for ID, title, description, and hours‐from‐now → adds OneTimeEvent.
-    - “remove” prompts for ID → removes that event.
-    - “list” → asks View to render current Model state.
-    - “next” → prints the next upcoming event.
-    - “quit” → exits.
+    - "add" prompts for ID, title, description, and hours-from-now → adds OneTimeEvent.
+    - "addat" prompts for ID, title, description, and timestamp → adds OneTimeEvent at a specific time.
+    - "remove" prompts for ID → removes that event.
+    - "list" → asks View to render current Model state.
+    - "next" → prints the next upcoming event.
+    - "quit" → exits.
 */
 class Controller
 {
@@ -28,6 +29,10 @@ private:
 
     // Return a string “YYYY‑MM‑DD HH:MM” from a time_point.
     static std::string formatTimePoint(const std::chrono::system_clock::time_point &tp);
+
+    // Parse a timestamp string "YYYY-MM-DD HH:MM" into a time_point.
+    static std::chrono::system_clock::time_point
+    parseTimePoint(const std::string &timestamp);
 
     // Print the next upcoming event or “no upcoming events”.
     void printNextEvent();

--- a/model/Event.h
+++ b/model/Event.h
@@ -2,6 +2,7 @@
 
 using namespace std;
 #include <string>
+#include <chrono>
 class Event
 {
 protected:

--- a/model/OneTimeEvent.h
+++ b/model/OneTimeEvent.h
@@ -1,4 +1,5 @@
 #include "Event.h"
+#include <chrono>
 class OneTimeEvent : public Event
 {
 private:

--- a/model/RecurringEvent.h
+++ b/model/RecurringEvent.h
@@ -1,5 +1,8 @@
 #include "Event.h"
 #include "recurrence/RecurrencePattern.h"
+#include <chrono>
+#include <vector>
+#include <string>
 class RecurringEvent : public Event
 {
 private:

--- a/model/recurrence/DailyRecurrence.h
+++ b/model/recurrence/DailyRecurrence.h
@@ -1,4 +1,6 @@
 #include "RecurrencePattern.h"
+#include <chrono>
+#include <vector>
 
 // This pattern handles the "Every x days" recurrence
 // Example: every 7 days I want to order Nandos.

--- a/model/recurrence/RecurrencePattern.h
+++ b/model/recurrence/RecurrencePattern.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <chrono>
 using namespace std;
 
 // This is a recurrence pattern which the RecurringEvent will be composed with.

--- a/model/recurrence/WeeklyRecurrence.h
+++ b/model/recurrence/WeeklyRecurrence.h
@@ -1,5 +1,6 @@
 #include "RecurrencePattern.h"
 #include <vector>
+#include <chrono>
 #include "../../utils/WeekDay.h"
 // This pattern handles the every x weeks on yDay and zDay walk the dalk.
 // For example, every week on Tuesday and Thursday, I have Object Oriented Design Class.


### PR DESCRIPTION
## Summary
- enable scheduling events using an absolute timestamp via new `addat` command
- add helper for parsing timestamp strings
- update docs and command list
- include missing `<chrono>` headers so build works

## Testing
- `make clean && make`
- `./scheduler <<EOF
addat
123
Title
Desc
2023-01-01 12:00
list
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684198853c28832a93f092dbccead5c9