### PR TITLE
Add structured test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,18 +28,59 @@ $(TARGET): $(OBJS)
 
 # Clean up intermediate and output files
 clean:
-	rm -f $(OBJS) $(TARGET) $(TEST_OBJS) $(TEST_TARGET)
+	rm -f $(OBJS) $(TARGET) \
+	      $(RECURRENCE_TEST_OBJS) $(EVENT_TEST_OBJS) \
+	      $(MODEL_TEST_OBJS) $(CONTROLLER_TEST_OBJS) \
+	      $(TEST_TARGETS)
 
 # Test setup
-TEST_SRCS = tests/recurrence_tests.cpp \
-            model/recurrence/DailyRecurrence.cpp \
-            model/recurrence/WeeklyRecurrence.cpp 
-TEST_OBJS = $(TEST_SRCS:.cpp=.o)
-TEST_TARGET = recurrence_tests
+RECURRENCE_TEST_SRCS = tests/recurrence/recurrence_tests.cpp \
+                       model/recurrence/DailyRecurrence.cpp \
+                       model/recurrence/WeeklyRecurrence.cpp
+RECURRENCE_TEST_OBJS = $(RECURRENCE_TEST_SRCS:.cpp=.o)
+RECURRENCE_TEST_TARGET = recurrence_tests
 
-test: $(TEST_TARGET)
+EVENT_TEST_SRCS = tests/events/event_tests.cpp \
+                  model/OneTimeEvent.cpp \
+                  model/RecurringEvent.cpp \
+                  model/recurrence/DailyRecurrence.cpp \
+                  model/recurrence/WeeklyRecurrence.cpp
+EVENT_TEST_OBJS = $(EVENT_TEST_SRCS:.cpp=.o)
+EVENT_TEST_TARGET = event_tests
 
-$(TEST_TARGET): $(TEST_OBJS)
-	$(CXX) $(CXXFLAGS) $(TEST_OBJS) -o $(TEST_TARGET)
+MODEL_TEST_SRCS = tests/model/model_tests.cpp \
+                  model/Model.cpp \
+                  model/OneTimeEvent.cpp \
+                  model/RecurringEvent.cpp \
+                  model/recurrence/DailyRecurrence.cpp \
+                  model/recurrence/WeeklyRecurrence.cpp
+MODEL_TEST_OBJS = $(MODEL_TEST_SRCS:.cpp=.o)
+MODEL_TEST_TARGET = model_tests
+
+CONTROLLER_TEST_SRCS = tests/controller/controller_tests.cpp \
+                       controller/Controller.cpp \
+                       model/Model.cpp \
+                       model/OneTimeEvent.cpp \
+                       model/RecurringEvent.cpp \
+                       model/recurrence/DailyRecurrence.cpp \
+                       model/recurrence/WeeklyRecurrence.cpp
+CONTROLLER_TEST_OBJS = $(CONTROLLER_TEST_SRCS:.cpp=.o)
+CONTROLLER_TEST_TARGET = controller_tests
+
+TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(CONTROLLER_TEST_TARGET)
+
+test: $(TEST_TARGETS)
+
+$(RECURRENCE_TEST_TARGET): $(RECURRENCE_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(RECURRENCE_TEST_OBJS) -o $@
+
+$(EVENT_TEST_TARGET): $(EVENT_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(EVENT_TEST_OBJS) -o $@
+
+$(MODEL_TEST_TARGET): $(MODEL_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(MODEL_TEST_OBJS) -o $@
+
+$(CONTROLLER_TEST_TARGET): $(CONTROLLER_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(CONTROLLER_TEST_OBJS) -o $@
 
 .PHONY: test

--- a/tests/controller/controller_tests.cpp
+++ b/tests/controller/controller_tests.cpp
@@ -1,0 +1,61 @@
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include "../../model/Model.h"
+#include "../../model/OneTimeEvent.h"
+#include "../test_utils.h"
+
+#define private public
+#include "../../controller/Controller.h"
+#undef private
+
+using namespace std;
+using namespace chrono;
+
+static void testControllerParseFormat()
+{
+    auto tp = Controller::parseTimePoint("2025-06-01 09:30");
+    string s = Controller::formatTimePoint(tp);
+    assert(s == "2025-06-01 09:30");
+
+    bool threw = false;
+    try { Controller::parseTimePoint("bad format"); }
+    catch(const exception&) { threw = true; }
+    assert(threw);
+}
+
+static void testControllerPrintNextEvent()
+{
+    Model m({});
+    OneTimeEvent e1("1","d","t", makeTime(2025,6,1,9), hours(1));
+    m.addEvent(e1);
+    StubView v(m);
+    Controller c(m,v);
+
+    std::ostringstream ss;
+    auto old = cout.rdbuf(ss.rdbuf());
+    c.printNextEvent();
+    cout.rdbuf(old);
+    assert(ss.str().find("[1]") != string::npos);
+}
+
+static void testControllerPrintNextEventNone()
+{
+    Model m({});
+    StubView v(m);
+    Controller c(m,v);
+    std::ostringstream ss;
+    auto old = cout.rdbuf(ss.rdbuf());
+    c.printNextEvent();
+    cout.rdbuf(old);
+    assert(ss.str().find("no upcoming events") != string::npos);
+}
+
+int main()
+{
+    testControllerParseFormat();
+    testControllerPrintNextEvent();
+    testControllerPrintNextEventNone();
+    cout << "Controller tests passed\n";
+    return 0;
+}

--- a/tests/events/event_tests.cpp
+++ b/tests/events/event_tests.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <iostream>
+#include <vector>
+#include "../../model/OneTimeEvent.h"
+#include "../../model/RecurringEvent.h"
+#include "../../model/recurrence/DailyRecurrence.h"
+#include "../../model/recurrence/WeeklyRecurrence.h"
+#include "../../utils/WeekDay.h"
+#include "../test_utils.h"
+
+using namespace std;
+using namespace chrono;
+
+static void testOneTimeEvent()
+{
+    auto tp = makeTime(2025,1,1,12);
+    OneTimeEvent e("1","desc","title", tp, hours(2));
+    assert(e.getId() == "1");
+    assert(e.getDescription() == "desc");
+    assert(e.getTitle() == "title");
+    assert(e.getTime() == tp);
+    assert(e.getDuration() == hours(2));
+}
+
+static void testRecurringEventDelegation()
+{
+    FakePattern pat;
+    pat.dueResult = true;
+    pat.nextResult.push_back(makeTime(2030,1,1,8));
+    string id = "R";
+    string desc = "d";
+    string title = "t";
+    RecurringEvent ev(id, desc, title, makeTime(2030,1,1,8), hours(1), pat);
+    assert(ev.isDueOn(makeTime(2030,1,1,8)));
+    assert(pat.isDueCalled);
+    auto nxt = ev.getNextNOccurrences(makeTime(2029,12,31,0), 1);
+    assert(pat.getNextCalled);
+    assert(nxt.size() == 1 && nxt[0] == makeTime(2030,1,1,8));
+}
+
+int main()
+{
+    testOneTimeEvent();
+    testRecurringEventDelegation();
+    cout << "Event tests passed\n";
+    return 0;
+}

--- a/tests/model/model_tests.cpp
+++ b/tests/model/model_tests.cpp
@@ -1,0 +1,61 @@
+#include <cassert>
+#include <iostream>
+#include "../../model/Model.h"
+#include "../../model/OneTimeEvent.h"
+#include "../../model/RecurringEvent.h"
+#include "../../model/recurrence/DailyRecurrence.h"
+#include "../../model/recurrence/WeeklyRecurrence.h"
+#include "../test_utils.h"
+
+using namespace std;
+using namespace chrono;
+
+static void testModelAddAndRetrieve()
+{
+    Model m({});
+    OneTimeEvent e1("1","d1","t1", makeTime(2025,1,2,9), hours(1));
+    OneTimeEvent e2("2","d2","t2", makeTime(2025,1,1,8), hours(1));
+    m.addEvent(e1);
+    m.addEvent(e2);
+    auto next = m.getNextEvent();
+    assert(next.getId() == "2");
+    auto all = m.getEvents(-1, makeTime(2025,1,3,0));
+    assert(all.size() == 2);
+    assert(all[0].getId() == "2");
+    assert(all[1].getId() == "1");
+}
+
+static void testModelRemove()
+{
+    Model m({});
+    OneTimeEvent e1("1","d1","t1", makeTime(2025,1,1,9), hours(1));
+    OneTimeEvent e2("2","d2","t2", makeTime(2025,1,2,9), hours(1));
+    m.addEvent(e1);
+    m.addEvent(e2);
+    assert(m.removeEvent("1"));
+    assert(!m.removeEvent("3"));
+    auto all = m.getEvents(-1, makeTime(2025,1,3,0));
+    assert(all.size() == 1 && all[0].getId() == "2");
+}
+
+static void testModelGetEventsLimit()
+{
+    Model m({});
+    OneTimeEvent e1("1","d1","t1", makeTime(2025,1,1,8), hours(1));
+    OneTimeEvent e2("2","d2","t2", makeTime(2025,1,2,8), hours(1));
+    OneTimeEvent e3("3","d3","t3", makeTime(2025,1,3,8), hours(1));
+    m.addEvent(e1); m.addEvent(e2); m.addEvent(e3);
+    auto limited = m.getEvents(2, makeTime(2025,1,4,0));
+    assert(limited.size() == 2);
+    auto cutoff = m.getEvents(-1, makeTime(2025,1,2,12));
+    assert(cutoff.size() == 2);
+}
+
+int main()
+{
+    testModelAddAndRetrieve();
+    testModelRemove();
+    testModelGetEventsLimit();
+    cout << "Model tests passed\n";
+    return 0;
+}

--- a/tests/recurrence/recurrence_tests.cpp
+++ b/tests/recurrence/recurrence_tests.cpp
@@ -2,9 +2,9 @@
 #include <iostream>
 #include <vector>
 #include <ctime>
-#include "../model/recurrence/DailyRecurrence.h"
-#include "../model/recurrence/WeeklyRecurrence.h"
-#include "../utils/WeekDay.h"
+#include "../../model/recurrence/DailyRecurrence.h"
+#include "../../model/recurrence/WeeklyRecurrence.h"
+#include "../../utils/WeekDay.h"
 
 using namespace std;
 using namespace chrono;

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <chrono>
+#include <ctime>
+#include "../view/View.h"
+#include "../model/ReadOnlyModel.h"
+#include "../model/recurrence/RecurrencePattern.h"
+
+inline std::chrono::system_clock::time_point makeTime(int year, int month, int day,
+                                                      int hour=0, int min=0, int sec=0)
+{
+    std::tm tm{};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = min;
+    tm.tm_sec = sec;
+    tm.tm_isdst = -1;
+    time_t tt = timegm(&tm);
+    return std::chrono::system_clock::from_time_t(tt);
+}
+
+class StubView : public View
+{
+public:
+    explicit StubView(const ReadOnlyModel &m) : View(m) {}
+    void render() override {}
+};
+
+class FakePattern : public RecurrencePattern
+{
+public:
+    mutable bool isDueCalled = false;
+    mutable bool getNextCalled = false;
+    bool dueResult = false;
+    std::vector<std::chrono::system_clock::time_point> nextResult;
+
+    std::vector<std::chrono::system_clock::time_point> getNextNOccurrences(
+            std::chrono::system_clock::time_point, int) const override
+    {
+        getNextCalled = true;
+        return nextResult;
+    }
+    bool isDueOn(std::chrono::system_clock::time_point) const override
+    {
+        isDueCalled = true;
+        return dueResult;
+    }
+};


### PR DESCRIPTION
## Summary
- restructure tests into dedicated suites for events, model, controller, and recurrence patterns
- centralize helpers in `tests/test_utils.h`
- update Makefile to build each suite separately
- fix include paths and controller test setup

## Testing
- `make test`
- `./recurrence_tests`
- `./event_tests`
- `./model_tests`
- `./controller_tests`


------
https://chatgpt.com/codex/tasks/task_e_68419fb8f638832a9fd3a9e262880920