### PR TITLE
Handle UTC times internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Personal Scheduler
+
+All event timestamps are stored internally in UTC to ensure consistent
+behavior across time zones. When interacting with the CLI you provide and
+view times in your **local time zone**. The scheduler converts local input
+times to UTC for storage and converts them back to local time when events
+are displayed.
+
+Summary:
+- **Input and output:** local time
+- **Internal storage:** UTC

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -16,6 +16,7 @@ Controller::Controller(Model &model, View &view)
 {
 }
 
+// Convert a UTC time_point to a local timestamp string
 string Controller::formatTimePoint(const system_clock::time_point &tp)
 {
     time_t t_c = system_clock::to_time_t(tp);
@@ -30,6 +31,7 @@ string Controller::formatTimePoint(const system_clock::time_point &tp)
     return string(buf);
 }
 
+// Interpret a local timestamp string and convert it to a UTC time_point
 system_clock::time_point Controller::parseTimePoint(const string &timestamp)
 {
     std::tm tm_buf{};
@@ -63,6 +65,8 @@ void Controller::printNextEvent()
 void Controller::run()
 {
     cout << "=== Scheduler CLI ===\n";
+    cout << "(All times are entered and displayed in local time,\n"
+            " but stored internally in UTC.)\n";
     cout << "Commands: add  addat  remove  list  next  quit\n";
 
     string line;

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -27,10 +27,10 @@ private:
     Model &model_;
     View &view_;
 
-    // Return a string “YYYY‑MM‑DD HH:MM” from a time_point.
+    // Convert a UTC time_point to a local time string "YYYY-MM-DD HH:MM".
     static std::string formatTimePoint(const std::chrono::system_clock::time_point &tp);
 
-    // Parse a timestamp string "YYYY-MM-DD HH:MM" into a time_point.
+    // Parse a local time string "YYYY-MM-DD HH:MM" and return a UTC time_point.
     static std::chrono::system_clock::time_point
     parseTimePoint(const std::string &timestamp);
 

--- a/model/Event.h
+++ b/model/Event.h
@@ -9,14 +9,16 @@ protected:
     string id;
     string description;
     string title;
-    chrono::system_clock::time_point nextShowing;
+    // Stored in UTC regardless of the user's local timezone
+    chrono::system_clock::time_point timeUtc;
     chrono::system_clock::duration duration;
 
 public:
     Event(const string &id, const string &desc, const string &title, chrono::system_clock::time_point time,
           chrono::system_clock::duration duration)
-        : id(id), description(desc), title(title), nextShowing(time), duration(duration) {}
-    chrono::system_clock::time_point getTime() const { return nextShowing; }
+        : id(id), description(desc), title(title), timeUtc(time), duration(duration) {}
+    // Returned value is in UTC
+    chrono::system_clock::time_point getTime() const { return timeUtc; }
     chrono::system_clock::duration getDuration() const { return duration; }
     string getId() const { return id; }
     string getDescription() const { return description; }

--- a/model/recurrence/DailyRecurrence.h
+++ b/model/recurrence/DailyRecurrence.h
@@ -8,7 +8,8 @@
 class DailyRecurrence : public RecurrencePattern
 {
 private:
-    chrono::system_clock::time_point startingPoint; // First date
+    // First date/time of the recurrence (UTC)
+    chrono::system_clock::time_point startingPoint;
     int repeatingInterval;                          // This is the x in every x days.
     int maxOccurrences;                             // optional: stop after N times (-1 = unlimited)
     chrono::system_clock::time_point endDate;       // optional: stop by a certain date

--- a/model/recurrence/WeeklyRecurrence.h
+++ b/model/recurrence/WeeklyRecurrence.h
@@ -9,7 +9,8 @@
 class WeeklyRecurrence : public RecurrencePattern
 {
 private:
-    chrono::system_clock::time_point startingPoint; // First date/time
+    // First date/time of the recurrence (UTC)
+    chrono::system_clock::time_point startingPoint;
     vector<Weekday> daysOfTheWeek;                  // Which days of the week should this event run?
     int repeatingInterval;                          // This is the x in every x weeks.
     int maxOccurrences;                             // optional: stop after N times (-1 = unlimited)


### PR DESCRIPTION
## Summary
- clarify that all timestamps are stored in UTC
- rename Event field to `timeUtc`
- clarify conversion functions in `Controller`
- show notice about time handling in CLI
- document timezone behavior in README

## Testing
- `make test`
- `./recurrence_tests`
- `./event_tests`
- `./model_tests`
- `./controller_tests`


------
https://chatgpt.com/codex/tasks/task_e_6841a84d933c832ab0a5942ada46e894