### PR TITLE
Fix timezone handling for addat

### DIFF
--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -41,6 +41,10 @@ system_clock::time_point Controller::parseTimePoint(const string &timestamp)
     {
         throw std::runtime_error("Invalid timestamp format");
     }
+    // Let mktime determine daylight saving time so we don't misinterpret
+    // timestamps in locales that observe DST. Without this, events entered
+    // during DST could be shifted by one hour.
+    tm_buf.tm_isdst = -1;
     time_t time_c = std::mktime(&tm_buf);
     return system_clock::from_time_t(time_c);
 }

--- a/tests/controller/controller_tests.cpp
+++ b/tests/controller/controller_tests.cpp
@@ -22,6 +22,53 @@ static void testControllerParseFormat()
     try { Controller::parseTimePoint("bad format"); }
     catch(const exception&) { threw = true; }
     assert(threw);
+
+    const char* prev = getenv("TZ");
+    setenv("TZ", "Europe/Berlin", 1);
+    tzset();
+    auto tp2 = Controller::parseTimePoint("2025-06-05 12:00");
+    string s2 = Controller::formatTimePoint(tp2);
+    assert(s2 == "2025-06-05 12:00");
+    if (prev)
+        setenv("TZ", prev, 1);
+    else
+        unsetenv("TZ");
+    tzset();
+}
+
+static void testControllerParseFormatTimeZones()
+{
+    struct Case { const char* zone; const char* utc; } cases[] = {
+        {"UTC", "2025-06-05 12:00"},
+        {"Europe/London", "2025-06-05 11:00"},
+        {"America/Chicago", "2025-06-05 17:00"},
+        {"Asia/Tokyo", "2025-06-05 03:00"}
+    };
+
+    for (const auto &c : cases)
+    {
+        const char* prev = getenv("TZ");
+        setenv("TZ", c.zone, 1);
+        tzset();
+
+        auto tp = Controller::parseTimePoint("2025-06-05 12:00");
+        string round = Controller::formatTimePoint(tp);
+        assert(round == "2025-06-05 12:00");
+
+        time_t t = system_clock::to_time_t(tp);
+        tm gm;
+        gmtime_r(&t, &gm);
+        char buf[32];
+        strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &gm);
+        string utc = buf;
+        assert(utc == c.utc);
+
+        if (prev)
+            setenv("TZ", prev, 1);
+        else
+            unsetenv("TZ");
+        tzset();
+    }
 }
 
 static void testControllerPrintNextEvent()
@@ -54,6 +101,7 @@ static void testControllerPrintNextEventNone()
 int main()
 {
     testControllerParseFormat();
+    testControllerParseFormatTimeZones();
     testControllerPrintNextEvent();
     testControllerPrintNextEventNone();
     cout << "Controller tests passed\n";


### PR DESCRIPTION
## Summary
- preserve DST info when parsing local timestamps
- test parsing with a timezone that observes DST
- add checks for Chicago, London and Tokyo

## Testing
- `make clean && make test`
- `./recurrence_tests && ./event_tests && ./model_tests && ./controller_tests`


------
https://chatgpt.com/codex/tasks/task_e_6841aab36420832ab5efdb8efddaf781