### PR TITLE
Add recurring event support in controller and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,15 @@ MODEL_TEST_SRCS = tests/model/model_tests.cpp \
 MODEL_TEST_OBJS = $(MODEL_TEST_SRCS:.cpp=.o)
 MODEL_TEST_TARGET = model_tests
 
+MODEL_COMPREHENSIVE_TEST_SRCS = tests/model/model_comprehensive_tests.cpp \
+                                model/Model.cpp \
+                                model/OneTimeEvent.cpp \
+                                model/RecurringEvent.cpp \
+                                model/recurrence/DailyRecurrence.cpp \
+                                model/recurrence/WeeklyRecurrence.cpp
+MODEL_COMPREHENSIVE_TEST_OBJS = $(MODEL_COMPREHENSIVE_TEST_SRCS:.cpp=.o)
+MODEL_COMPREHENSIVE_TEST_TARGET = model_comprehensive_tests
+
 CONTROLLER_TEST_SRCS = tests/controller/controller_tests.cpp \
                        controller/Controller.cpp \
                        model/Model.cpp \
@@ -67,7 +76,7 @@ CONTROLLER_TEST_SRCS = tests/controller/controller_tests.cpp \
 CONTROLLER_TEST_OBJS = $(CONTROLLER_TEST_SRCS:.cpp=.o)
 CONTROLLER_TEST_TARGET = controller_tests
 
-TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(CONTROLLER_TEST_TARGET)
+TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET)
 
 test: $(TEST_TARGETS)
 
@@ -79,6 +88,9 @@ $(EVENT_TEST_TARGET): $(EVENT_TEST_OBJS)
 
 $(MODEL_TEST_TARGET): $(MODEL_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) $(MODEL_TEST_OBJS) -o $@
+
+$(MODEL_COMPREHENSIVE_TEST_TARGET): $(MODEL_COMPREHENSIVE_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(MODEL_COMPREHENSIVE_TEST_OBJS) -o $@
 
 $(CONTROLLER_TEST_TARGET): $(CONTROLLER_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) $(CONTROLLER_TEST_OBJS) -o $@

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -1,6 +1,7 @@
 // Controller.cpp
 #include "Controller.h"
 #include "../model/OneTimeEvent.h"
+#include "../model/RecurringEvent.h"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -64,6 +65,20 @@ void Controller::printNextEvent()
     {
         cout << "(no upcoming events)\n";
     }
+}
+
+void Controller::addRecurringEvent(const string &id,
+                                   const string &title,
+                                   const string &desc,
+                                   system_clock::time_point start,
+                                   system_clock::duration dur,
+                                   RecurrencePattern &pattern)
+{
+    string idCopy = id;
+    string descCopy = desc;
+    string titleCopy = title;
+    RecurringEvent e(idCopy, descCopy, titleCopy, start, dur, pattern);
+    model_.addEvent(e);
 }
 
 void Controller::run()

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "../model/Model.h"
+#include "../model/recurrence/RecurrencePattern.h"
 #include "../view/View.h"
 
 /*
@@ -36,4 +37,12 @@ private:
 
     // Print the next upcoming event or “no upcoming events”.
     void printNextEvent();
+
+    // Add a recurring event using an existing RecurrencePattern.
+    void addRecurringEvent(const std::string &id,
+                           const std::string &title,
+                           const std::string &desc,
+                           std::chrono::system_clock::time_point start,
+                           std::chrono::system_clock::duration dur,
+                           RecurrencePattern &pattern);
 };

--- a/tests/controller/controller_tests.cpp
+++ b/tests/controller/controller_tests.cpp
@@ -3,6 +3,8 @@
 #include <sstream>
 #include "../../model/Model.h"
 #include "../../model/OneTimeEvent.h"
+#include "../../model/RecurringEvent.h"
+#include "../../model/recurrence/DailyRecurrence.h"
 #include "../test_utils.h"
 
 #define private public
@@ -145,6 +147,26 @@ static void testControllerPrintNextEventNone()
     assert(ss.str().find("no upcoming events") != string::npos);
 }
 
+static void testControllerAddRecurring()
+{
+    Model m({});
+    StubView v(m);
+    Controller c(m,v);
+
+    auto start = makeTime(2025,6,1,9);
+    DailyRecurrence pattern(start, 1);
+    c.addRecurringEvent("R", "t", "d", start, hours(1), pattern);
+
+    OneTimeEvent o("O","d","t", makeTime(2025,6,2,9), hours(1));
+    m.addEvent(o);
+
+    std::ostringstream ss;
+    auto old = cout.rdbuf(ss.rdbuf());
+    c.printNextEvent();
+    cout.rdbuf(old);
+    assert(ss.str().find("[R]") != string::npos);
+}
+
 int main()
 {
     testControllerParseFormat();
@@ -152,6 +174,7 @@ int main()
     testControllerCrossTimeZones();
     testControllerPrintNextEvent();
     testControllerPrintNextEventNone();
+    testControllerAddRecurring();
     cout << "Controller tests passed\n";
     return 0;
 }

--- a/tests/model/model_comprehensive_tests.cpp
+++ b/tests/model/model_comprehensive_tests.cpp
@@ -1,0 +1,123 @@
+#include <cassert>
+#include <iostream>
+#include "../../model/Model.h"
+#include "../../model/OneTimeEvent.h"
+#include "../../model/RecurringEvent.h"
+#include "../../model/recurrence/DailyRecurrence.h"
+#include "../../model/recurrence/WeeklyRecurrence.h"
+#include "../test_utils.h"
+
+using namespace std;
+using namespace chrono;
+
+static void testAddMixedEvents()
+{
+    Model m({});
+    FakePattern pat;
+    OneTimeEvent o1("O1","d1","t1", makeTime(2025,6,1,8), hours(1));
+    OneTimeEvent o2("O2","d2","t2", makeTime(2025,6,2,8), hours(1));
+    string r1id = "R1"; string r1d = "dr1"; string r1t = "tr1";
+    string r2id = "R2"; string r2d = "dr2"; string r2t = "tr2";
+    RecurringEvent r1(r1id, r1d, r1t, makeTime(2025,6,2,9), hours(1), pat);
+    RecurringEvent r2(r2id, r2d, r2t, makeTime(2025,6,3,9), hours(1), pat);
+
+    m.addEvent(r2); // add out of order on purpose
+    m.addEvent(o1);
+    m.addEvent(r1);
+    m.addEvent(o2);
+
+    auto evs = m.getEvents(-1, makeTime(2025,6,4,0));
+    assert(evs.size() == 4);
+    assert(evs[0].getId() == "O1");
+    assert(evs[1].getId() == "O2");
+    assert(evs[2].getId() == "R1");
+    assert(evs[3].getId() == "R2");
+
+    Event next = m.getNextEvent();
+    assert(next.getId() == "O1");
+}
+
+static void testRemoveMixedEvents()
+{
+    Model m({});
+    FakePattern pat;
+    OneTimeEvent o1("O1","d1","t1", makeTime(2025,6,1,8), hours(1));
+    OneTimeEvent o2("O2","d2","t2", makeTime(2025,6,2,8), hours(1));
+    string r1id = "R1"; string r1d = "dr1"; string r1t = "tr1";
+    string r2id = "R2"; string r2d = "dr2"; string r2t = "tr2";
+    RecurringEvent r1(r1id, r1d, r1t, makeTime(2025,6,2,9), hours(1), pat);
+    RecurringEvent r2(r2id, r2d, r2t, makeTime(2025,6,3,9), hours(1), pat);
+    m.addEvent(o1); m.addEvent(o2); m.addEvent(r1); m.addEvent(r2);
+
+    assert(m.removeEvent("R1"));
+    assert(!m.removeEvent("NOPE"));
+    assert(m.removeEvent(o2));
+
+    auto evs = m.getEvents(-1, makeTime(2025,6,4,0));
+    assert(evs.size() == 2);
+    assert(evs[0].getId() == "O1");
+    assert(evs[1].getId() == "R2");
+}
+
+static void testNextEventThrows()
+{
+    Model m({});
+    bool threw = false;
+    try { m.getNextEvent(); }
+    catch(const runtime_error&) { threw = true; }
+    assert(threw);
+}
+
+static void testGetEventsLimitAndCutoff()
+{
+    Model m({});
+    FakePattern pat;
+    OneTimeEvent e1("E1","d","t", makeTime(2025,6,1,8), hours(1));
+    string r1id = "R1"; string r1d = "d1"; string r1t = "t1";
+    string r2id = "R2"; string r2d = "d2"; string r2t = "t2";
+    RecurringEvent r1(r1id, r1d, r1t, makeTime(2025,6,1,9), hours(1), pat);
+    OneTimeEvent e2("E2","d","t", makeTime(2025,6,2,8), hours(1));
+    RecurringEvent r2(r2id, r2d, r2t, makeTime(2025,6,3,8), hours(1), pat);
+    OneTimeEvent e3("E3","d","t", makeTime(2025,6,4,8), hours(1));
+    m.addEvent(e3); m.addEvent(r2); m.addEvent(e2); m.addEvent(r1); m.addEvent(e1);
+
+    auto limited = m.getEvents(3, makeTime(2025,6,3,0));
+    assert(limited.size() == 3);
+    assert(limited[0].getId() == "E1");
+    assert(limited[1].getId() == "R1");
+    assert(limited[2].getId() == "E2");
+
+    auto cutoff = m.getEvents(-1, makeTime(2025,6,2,12));
+    assert(cutoff.size() == 3);
+    assert(cutoff[2].getId() == "E2");
+}
+
+static void testDuplicatesAndSorting()
+{
+    Model m({});
+    FakePattern pat;
+    OneTimeEvent a("A","d","t", makeTime(2025,6,1,8), hours(1));
+    OneTimeEvent a2("A","d2","t2", makeTime(2025,6,1,9), hours(1));
+    string rid = "R"; string rd = "dr"; string rt = "tr";
+    RecurringEvent r(rid, rd, rt, makeTime(2025,5,31,8), hours(1), pat);
+
+    m.addEvent(a); m.addEvent(r); m.addEvent(a2); // duplicates allowed
+
+    auto evs = m.getEvents(-1, makeTime(2025,6,2,0));
+    assert(evs.size() == 3);
+    assert(evs[0].getId() == "R");
+    assert(evs[1].getId() == "A");
+    assert(evs[2].getId() == "A");
+}
+
+int main()
+{
+    testAddMixedEvents();
+    testRemoveMixedEvents();
+    testNextEventThrows();
+    testGetEventsLimitAndCutoff();
+    testDuplicatesAndSorting();
+    cout << "Comprehensive model tests passed\n";
+    return 0;
+}
+

--- a/tests/model/model_tests.cpp
+++ b/tests/model/model_tests.cpp
@@ -51,11 +51,34 @@ static void testModelGetEventsLimit()
     assert(cutoff.size() == 2);
 }
 
+static void testModelWithDailyRecurring()
+{
+    Model m({});
+    auto start = makeTime(2025,6,1,9);
+    DailyRecurrence rec(start, 1);
+    string id("R");
+    string desc("d");
+    string title("t");
+    RecurringEvent r(id, desc, title, start, hours(1), rec);
+    OneTimeEvent o("O","d","t", makeTime(2025,6,2,9), hours(1));
+    m.addEvent(o);
+    m.addEvent(r);
+
+    auto next = m.getNextEvent();
+    assert(next.getId() == "R");
+
+    auto evs = m.getEvents(-1, makeTime(2025,6,3,0));
+    assert(evs.size() == 2);
+    assert(evs[0].getId() == "R");
+    assert(evs[1].getId() == "O");
+}
+
 int main()
 {
     testModelAddAndRetrieve();
     testModelRemove();
     testModelGetEventsLimit();
+    testModelWithDailyRecurring();
     cout << "Model tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend Controller with helper to add recurring events
- update controller tests to cover recurring events
- expand model tests with daily recurring events

## Testing
- `make test`
- `./recurrence_tests && ./event_tests && ./model_tests && ./model_comprehensive_tests && ./controller_tests`


------
https://chatgpt.com/codex/tasks/task_e_6841b473aef0832aa0f32b89288a4673