### PR TITLE
Add SQLite backend via dependency injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ CXXFLAGS = -std=c++11 -Wall
 
 # Source files
 SRCS = main.cpp \
-	   controller/Controller.cpp \
+           controller/Controller.cpp \
        model/Model.cpp \
        model/OneTimeEvent.cpp \
        model/RecurringEvent.cpp \
        model/recurrence/DailyRecurrence.cpp \
        model/recurrence/WeeklyRecurrence.cpp \
-       view/TextualView.cpp
+       view/TextualView.cpp \
+       database/SQLiteScheduleDatabase.cpp
 
 # Object files (replace .cpp with .o)
 OBJS = $(SRCS:.cpp=.o)
@@ -20,7 +21,7 @@ TARGET = scheduler
 
 # Main build rule: link all object files into the executable
 $(TARGET): $(OBJS)
-	$(CXX) $(CXXFLAGS) $(OBJS) -o $(TARGET)
+	$(CXX) $(CXXFLAGS) $(OBJS) -lsqlite3 -o $(TARGET)
 
 # Rule to compile any .cpp into .o
 %.o: %.cpp

--- a/database/IScheduleDatabase.h
+++ b/database/IScheduleDatabase.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include "../model/Event.h"
+
+class IScheduleDatabase {
+public:
+    virtual ~IScheduleDatabase() = default;
+
+    virtual bool addEvent(const Event &e) = 0;
+    virtual bool removeEvent(const std::string &id) = 0;
+    virtual std::vector<Event> getAllEvents() const = 0;
+};

--- a/database/SQLiteScheduleDatabase.cpp
+++ b/database/SQLiteScheduleDatabase.cpp
@@ -1,0 +1,89 @@
+#include "SQLiteScheduleDatabase.h"
+#include <stdexcept>
+
+SQLiteScheduleDatabase::SQLiteScheduleDatabase(const std::string &path)
+    : db_(nullptr, sqlite3_close)
+{
+    sqlite3 *raw = nullptr;
+    if (sqlite3_open(path.c_str(), &raw) != SQLITE_OK)
+    {
+        throw std::runtime_error("Failed to open database");
+    }
+    db_.reset(raw);
+
+    const char *createSql =
+        "CREATE TABLE IF NOT EXISTS events ("
+        "id TEXT PRIMARY KEY,"
+        "description TEXT,"
+        "title TEXT,"
+        "time INTEGER,"
+        "duration INTEGER);";
+    char *errMsg = nullptr;
+    if (sqlite3_exec(db_.get(), createSql, nullptr, nullptr, &errMsg) != SQLITE_OK)
+    {
+        std::string msg = errMsg ? errMsg : "error creating table";
+        sqlite3_free(errMsg);
+        throw std::runtime_error(msg);
+    }
+}
+
+bool SQLiteScheduleDatabase::addEvent(const Event &e)
+{
+    const char *sql =
+        "INSERT OR REPLACE INTO events (id, description, title, time, duration) "
+        "VALUES (?,?,?,?,?);";
+    sqlite3_stmt *stmt = nullptr;
+    if (sqlite3_prepare_v2(db_.get(), sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return false;
+
+    sqlite3_bind_text(stmt, 1, e.getId().c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, e.getDescription().c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, e.getTitle().c_str(), -1, SQLITE_TRANSIENT);
+    long long timeSec = std::chrono::duration_cast<std::chrono::seconds>(
+                            e.getTime().time_since_epoch())
+                            .count();
+    sqlite3_bind_int64(stmt, 4, timeSec);
+    long long durSec =
+        std::chrono::duration_cast<std::chrono::seconds>(e.getDuration()).count();
+    sqlite3_bind_int64(stmt, 5, durSec);
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+bool SQLiteScheduleDatabase::removeEvent(const std::string &id)
+{
+    const char *sql = "DELETE FROM events WHERE id = ?;";
+    sqlite3_stmt *stmt = nullptr;
+    if (sqlite3_prepare_v2(db_.get(), sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return false;
+    sqlite3_bind_text(stmt, 1, id.c_str(), -1, SQLITE_TRANSIENT);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+std::vector<Event> SQLiteScheduleDatabase::getAllEvents() const
+{
+    const char *sql =
+        "SELECT id, description, title, time, duration FROM events ORDER BY time;";
+    sqlite3_stmt *stmt = nullptr;
+    if (sqlite3_prepare_v2(db_.get(), sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return {};
+
+    std::vector<Event> result;
+    while (sqlite3_step(stmt) == SQLITE_ROW)
+    {
+        std::string id = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+        std::string desc = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 1));
+        std::string title = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 2));
+        long long timeSec = sqlite3_column_int64(stmt, 3);
+        long long durSec = sqlite3_column_int64(stmt, 4);
+        auto tp = std::chrono::system_clock::time_point(std::chrono::seconds(timeSec));
+        auto dur = std::chrono::seconds(durSec);
+        result.emplace_back(id, desc, title, tp, dur);
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}

--- a/database/SQLiteScheduleDatabase.h
+++ b/database/SQLiteScheduleDatabase.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "IScheduleDatabase.h"
+#include <memory>
+#include <sqlite3.h>
+#include <string>
+
+class SQLiteScheduleDatabase : public IScheduleDatabase {
+public:
+    explicit SQLiteScheduleDatabase(const std::string &path);
+    ~SQLiteScheduleDatabase() override = default;
+
+    bool addEvent(const Event &e) override;
+    bool removeEvent(const std::string &id) override;
+    std::vector<Event> getAllEvents() const override;
+
+private:
+    std::unique_ptr<sqlite3, decltype(&sqlite3_close)> db_;
+};

--- a/main.cpp
+++ b/main.cpp
@@ -2,13 +2,15 @@
 #include "model/Model.h"
 #include "view/TextualView.h"
 #include "controller/Controller.h"
+#include "database/SQLiteScheduleDatabase.h"
 #include <vector>
 
 int main()
 {
-    // 1) Construct an initially empty Model.
+    // 1) Construct the database and model using dependency injection.
+    SQLiteScheduleDatabase db("events.db");
     vector<Event> initialEvents;
-    Model model(initialEvents);
+    Model model(initialEvents, &db);
 
     // 2) Construct a TextualView, passing the Model as ReadOnlyModel.
     TextualView view(model);

--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -12,10 +12,14 @@ void Model::sortEvents()
               });
 }
 
-// Constructor: take the incoming vector, move it in, then sort.
-Model::Model(std::vector<Event> init)
-    : events(std::move(init))
+// Constructor: optionally load events from a database, otherwise use provided list.
+Model::Model(std::vector<Event> init, IScheduleDatabase *db)
+    : events(std::move(init)), db_(db)
 {
+    if (db_)
+    {
+        events = db_->getAllEvents();
+    }
     sortEvents();
 }
 
@@ -59,6 +63,10 @@ bool Model::addEvent(Event &e)
 {
     events.push_back(e);
     sortEvents();
+    if (db_)
+    {
+        db_->addEvent(e);
+    }
     return true;
 }
 
@@ -76,5 +84,10 @@ bool Model::removeEvent(const std::string &id)
                                     return ev.getId() == id;
                                 }),
                  events.end());
-    return events.size() < beforeSize;
+    bool removed = events.size() < beforeSize;
+    if (removed && db_)
+    {
+        db_->removeEvent(id);
+    }
+    return removed;
 }

--- a/model/Model.h
+++ b/model/Model.h
@@ -5,6 +5,7 @@
 #include <string>
 #include "Event.h"
 #include "ReadOnlyModel.h"
+#include "../database/IScheduleDatabase.h"
 
 /*
   Model extends ReadOnlyModel by adding mutators (addEvent, removeEvent).
@@ -14,13 +15,14 @@ class Model : public ReadOnlyModel
 {
 private:
     std::vector<Event> events;
+    IScheduleDatabase *db_;
 
     // Re‐sort the internal list whenever it changes.
     void sortEvents();
 
 public:
-    // Construct with an initial list of events. They’re sorted right away.
-    explicit Model(std::vector<Event> init);
+    // Construct with an initial list of events and optional database.
+    explicit Model(std::vector<Event> init, IScheduleDatabase *db = nullptr);
 
     // ReadOnlyModel overrides (note the const):
     std::vector<Event>


### PR DESCRIPTION
## Summary
- add database abstraction layer with `IScheduleDatabase`
- implement `SQLiteScheduleDatabase` using sqlite3 C API
- integrate Model with optional database
- inject the SQLite database in `main.cpp`
- update Makefile to build the new files and link with sqlite3

## Testing
- `make test`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6841bb39531c832a91ab90148535728e