### PR TITLE
Remove manual ID entry

### DIFF
--- a/api/ApiServer.cpp
+++ b/api/ApiServer.cpp
@@ -98,7 +98,7 @@ void ApiServer::setupRoutes()
         json out;
         try {
             auto body = json::parse(req.body);
-            std::string id = body.at("id");
+            std::string id = model_.generateUniqueId();
             std::string title = body.value("title", "");
             std::string description = body.value("description", "");
             std::string timeStr = body.at("time");

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -67,18 +67,18 @@ void Controller::printNextEvent()
     }
 }
 
-void Controller::addRecurringEvent(const string &id,
-                                   const string &title,
-                                   const string &desc,
-                                   system_clock::time_point start,
-                                   system_clock::duration dur,
-                                   RecurrencePattern &pattern)
+string Controller::addRecurringEvent(const string &title,
+                                     const string &desc,
+                                     system_clock::time_point start,
+                                     system_clock::duration dur,
+                                     RecurrencePattern &pattern)
 {
-    string idCopy = id;
+    string idCopy = model_.generateUniqueId();
     string descCopy = desc;
     string titleCopy = title;
     RecurringEvent e(idCopy, descCopy, titleCopy, start, dur, pattern);
     model_.addEvent(e);
+    return idCopy;
 }
 
 void Controller::run()
@@ -101,10 +101,8 @@ void Controller::run()
         iss >> cmd;
         if (cmd == "add")
         {
-            // Prompt for ID, title, description, hours-from-now:
-            cout << "Enter event ID: ";
-            string id;
-            getline(cin, id);
+            // Prompt for title, description, hours-from-now:
+            string id = model_.generateUniqueId();
             cout << "Enter title: ";
             string title;
             getline(cin, title);
@@ -126,10 +124,8 @@ void Controller::run()
         }
         else if (cmd == "addat")
         {
-            // Prompt for ID, title, description, timestamp
-            cout << "Enter event ID: ";
-            string id;
-            getline(cin, id);
+            // Prompt for title, description, timestamp
+            string id = model_.generateUniqueId();
             cout << "Enter title: ";
             string title;
             getline(cin, title);

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -8,8 +8,8 @@
 
 /*
   Controller coordinates a Model and a View.  It runs a simple CLI loop:
-    - "add" prompts for ID, title, description, and hours-from-now → adds OneTimeEvent.
-    - "addat" prompts for ID, title, description, and timestamp → adds OneTimeEvent at a specific time.
+    - "add" prompts for title, description, and hours-from-now → adds OneTimeEvent with an auto-generated ID.
+    - "addat" prompts for title, description, and timestamp → adds OneTimeEvent at a specific time with an auto-generated ID.
     - "remove" prompts for ID → removes that event.
     - "list" → asks View to render current Model state.
     - "next" → prints the next upcoming event.
@@ -38,11 +38,10 @@ private:
     // Print the next upcoming event or “no upcoming events”.
     void printNextEvent();
 
-    // Add a recurring event using an existing RecurrencePattern.
-    void addRecurringEvent(const std::string &id,
-                           const std::string &title,
-                           const std::string &desc,
-                           std::chrono::system_clock::time_point start,
-                           std::chrono::system_clock::duration dur,
-                           RecurrencePattern &pattern);
+    // Add a recurring event using an existing RecurrencePattern. Returns the ID of the new event.
+    std::string addRecurringEvent(const std::string &title,
+                                  const std::string &desc,
+                                  std::chrono::system_clock::time_point start,
+                                  std::chrono::system_clock::duration dur,
+                                  RecurrencePattern &pattern);
 };

--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -1,6 +1,8 @@
 #include "Model.h"
 #include <algorithm> // for std::sort, std::remove_if
 #include <stdexcept> // for std::runtime_error
+#include <random>
+#include <sstream>
 
 // Re‐sort internal list so that events are in ascending time order.
 void Model::sortEvents()
@@ -10,6 +12,27 @@ void Model::sortEvents()
               {
                   return a.getTime() < b.getTime();
               });
+}
+
+bool Model::eventExists(const std::string &id) const
+{
+    return std::any_of(events.begin(), events.end(), [&](const Event &ev) {
+        return ev.getId() == id;
+    });
+}
+
+std::string Model::generateUniqueId() const
+{
+    static std::mt19937_64 gen(std::random_device{}());
+    static std::uniform_int_distribution<uint64_t> dist;
+    std::string id;
+    do
+    {
+        std::stringstream ss;
+        ss << std::hex << dist(gen);
+        id = ss.str();
+    } while (eventExists(id));
+    return id;
 }
 
 // Constructor: optionally load events from a database, otherwise use provided list.
@@ -61,6 +84,10 @@ Event Model::getNextEvent() const
 
 bool Model::addEvent(Event &e)
 {
+    if (eventExists(e.getId()))
+    {
+        return false;
+    }
     events.push_back(e);
     sortEvents();
     if (db_)

--- a/model/Model.h
+++ b/model/Model.h
@@ -17,6 +17,9 @@ private:
     std::vector<Event> events;
     IScheduleDatabase *db_;
 
+    // Check if an event ID already exists in the current list
+    bool eventExists(const std::string &id) const;
+
     // Re‐sort the internal list whenever it changes.
     void sortEvents();
 
@@ -41,4 +44,7 @@ public:
 
     // Remove by ID. Returns true if at least one Event with that ID was erased.
     bool removeEvent(const std::string &id);
+
+    // Generate a unique ID not currently in use
+    std::string generateUniqueId() const;
 };

--- a/tests/controller/controller_tests.cpp
+++ b/tests/controller/controller_tests.cpp
@@ -155,7 +155,7 @@ static void testControllerAddRecurring()
 
     auto start = makeTime(2025,6,1,9);
     DailyRecurrence pattern(start, 1);
-    c.addRecurringEvent("R", "t", "d", start, hours(1), pattern);
+    std::string id = c.addRecurringEvent("t", "d", start, hours(1), pattern);
 
     OneTimeEvent o("O","d","t", makeTime(2025,6,2,9), hours(1));
     m.addEvent(o);
@@ -164,7 +164,7 @@ static void testControllerAddRecurring()
     auto old = cout.rdbuf(ss.rdbuf());
     c.printNextEvent();
     cout.rdbuf(old);
-    assert(ss.str().find("[R]") != string::npos);
+    assert(ss.str().find("[" + id + "]") != string::npos);
 }
 
 int main()

--- a/tests/model/model_comprehensive_tests.cpp
+++ b/tests/model/model_comprehensive_tests.cpp
@@ -92,22 +92,18 @@ static void testGetEventsLimitAndCutoff()
     assert(cutoff[2].getId() == "E2");
 }
 
-static void testDuplicatesAndSorting()
+static void testDuplicatesRejected()
 {
     Model m({});
-    FakePattern pat;
     OneTimeEvent a("A","d","t", makeTime(2025,6,1,8), hours(1));
     OneTimeEvent a2("A","d2","t2", makeTime(2025,6,1,9), hours(1));
-    string rid = "R"; string rd = "dr"; string rt = "tr";
-    RecurringEvent r(rid, rd, rt, makeTime(2025,5,31,8), hours(1), pat);
 
-    m.addEvent(a); m.addEvent(r); m.addEvent(a2); // duplicates allowed
+    assert(m.addEvent(a));
+    assert(!m.addEvent(a2));
 
     auto evs = m.getEvents(-1, makeTime(2025,6,2,0));
-    assert(evs.size() == 3);
-    assert(evs[0].getId() == "R");
-    assert(evs[1].getId() == "A");
-    assert(evs[2].getId() == "A");
+    assert(evs.size() == 1);
+    assert(evs[0].getId() == "A");
 }
 
 int main()
@@ -116,7 +112,7 @@ int main()
     testRemoveMixedEvents();
     testNextEventThrows();
     testGetEventsLimitAndCutoff();
-    testDuplicatesAndSorting();
+    testDuplicatesRejected();
     cout << "Comprehensive model tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- auto-generate IDs for events using Model::generateUniqueId
- prevent duplicate IDs by checking existing events
- update controller to generate IDs for `add` and `addat` commands
- return the ID from `addRecurringEvent`
- adjust API server to create IDs automatically
- update tests for new ID behavior

## Testing
- `make test`
- `./recurrence_tests && ./event_tests && ./model_tests && ./model_comprehensive_tests && ./controller_tests`

------
https://chatgpt.com/codex/tasks/task_e_6841d4d6edb4832aacc2f59b9cea2f5b