### PR TITLE
Fix UTC handling in Model event queries

### DIFF
--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -124,14 +124,18 @@ static std::chrono::system_clock::time_point startOfDay(std::chrono::system_cloc
     time_t t = std::chrono::system_clock::to_time_t(tp);
     std::tm tm_buf;
 #if defined(_MSC_VER)
-    localtime_s(&tm_buf, &t);
+    gmtime_s(&tm_buf, &t);
 #else
-    localtime_r(&t, &tm_buf);
+    gmtime_r(&t, &tm_buf);
 #endif
     tm_buf.tm_hour = 0;
     tm_buf.tm_min = 0;
     tm_buf.tm_sec = 0;
-    time_t start_t = std::mktime(&tm_buf);
+#if defined(_MSC_VER)
+    time_t start_t = _mkgmtime(&tm_buf);
+#else
+    time_t start_t = timegm(&tm_buf);
+#endif
     return std::chrono::system_clock::from_time_t(start_t);
 }
 
@@ -156,9 +160,9 @@ std::vector<Event> Model::getEventsInWeek(std::chrono::system_clock::time_point 
     time_t t = std::chrono::system_clock::to_time_t(day);
     std::tm tm_buf;
 #if defined(_MSC_VER)
-    localtime_s(&tm_buf, &t);
+    gmtime_s(&tm_buf, &t);
 #else
-    localtime_r(&t, &tm_buf);
+    gmtime_r(&t, &tm_buf);
 #endif
     int wday = tm_buf.tm_wday; // 0=Sunday
     int diff = (wday + 6) % 7; // days since Monday
@@ -181,18 +185,26 @@ std::vector<Event> Model::getEventsInMonth(std::chrono::system_clock::time_point
     time_t t = std::chrono::system_clock::to_time_t(day);
     std::tm tm_buf;
 #if defined(_MSC_VER)
-    localtime_s(&tm_buf, &t);
+    gmtime_s(&tm_buf, &t);
 #else
-    localtime_r(&t, &tm_buf);
+    gmtime_r(&t, &tm_buf);
 #endif
     tm_buf.tm_mday = 1;
     tm_buf.tm_hour = 0;
     tm_buf.tm_min = 0;
     tm_buf.tm_sec = 0;
-    time_t start_t = std::mktime(&tm_buf);
+#if defined(_MSC_VER)
+    time_t start_t = _mkgmtime(&tm_buf);
+#else
+    time_t start_t = timegm(&tm_buf);
+#endif
     auto start = std::chrono::system_clock::from_time_t(start_t);
     tm_buf.tm_mon += 1;
-    time_t end_t = std::mktime(&tm_buf);
+#if defined(_MSC_VER)
+    time_t end_t = _mkgmtime(&tm_buf);
+#else
+    time_t end_t = timegm(&tm_buf);
+#endif
     auto end = std::chrono::system_clock::from_time_t(end_t);
 
     std::vector<Event> result;

--- a/tests/model/model_tests.cpp
+++ b/tests/model/model_tests.cpp
@@ -112,6 +112,30 @@ static void testEventsInMonth()
     assert(evs[1].getId() == "3");
 }
 
+static void testEventsTimeZones()
+{
+    const char *prev = getenv("TZ");
+    setenv("TZ", "Europe/Berlin", 1);
+    tzset();
+
+    Model m({});
+    OneTimeEvent e("1","d","t", makeTime(2025,6,1,9), hours(1));
+    m.addEvent(e);
+
+    auto d = m.getEventsOnDay(makeTime(2025,6,1,0));
+    assert(d.size() == 1);
+    auto w = m.getEventsInWeek(makeTime(2025,6,1,0));
+    assert(w.size() == 1);
+    auto mo = m.getEventsInMonth(makeTime(2025,6,1,0));
+    assert(mo.size() == 1);
+
+    if (prev)
+        setenv("TZ", prev, 1);
+    else
+        unsetenv("TZ");
+    tzset();
+}
+
 int main()
 {
     testModelAddAndRetrieve();
@@ -121,6 +145,7 @@ int main()
     testEventsOnDay();
     testEventsInWeek();
     testEventsInMonth();
+    testEventsTimeZones();
     cout << "Model tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- use gmtime/timegm instead of localtime/mktime so event queries work correctly regardless of system timezone
- add regression test verifying day/week/month queries under different TZ settings

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841ddfacbcc832ab7b81a6fe19278ab