### PR TITLE
Enable CORS on API

### DIFF
--- a/api/ApiServer.cpp
+++ b/api/ApiServer.cpp
@@ -49,6 +49,11 @@ static system_clock::time_point parseMonth(const std::string &monthStr)
 ApiServer::ApiServer(Model &model, int port)
     : model_(model), port_(port)
 {
+    server_.set_default_headers({
+        {"Access-Control-Allow-Origin", "*"},
+        {"Access-Control-Allow-Headers", "Content-Type"},
+        {"Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS"}
+    });
     setupRoutes();
 }
 
@@ -76,6 +81,13 @@ static json eventToJson(const Event &e)
 
 void ApiServer::setupRoutes()
 {
+    server_.Options(R"(.*)", [](const httplib::Request &, httplib::Response &res)
+                    {
+        res.set_header("Access-Control-Allow-Origin", "*");
+        res.set_header("Access-Control-Allow-Headers", "Content-Type");
+        res.set_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+    });
+
     server_.Get("/events", [this](const httplib::Request &, httplib::Response &res)
                 {
         std::cout << "GET /events" << std::endl;

--- a/tests/api/api_tests.cpp
+++ b/tests/api/api_tests.cpp
@@ -73,10 +73,27 @@ static void testMonthEndpoint() {
     th.join();
 }
 
+static void testCORSEnabled() {
+    Model m({});
+    ApiServer srv(m, 8088);
+    thread th(runServer, std::ref(srv));
+    this_thread::sleep_for(milliseconds(100));
+
+    httplib::Client cli("localhost", 8088);
+    auto res = cli.Options("/events");
+    assert(res && res->status == 200);
+    assert(res->get_header_value("Access-Control-Allow-Origin") == "*");
+    assert(!res->get_header_value("Access-Control-Allow-Methods").empty());
+
+    srv.stop();
+    th.join();
+}
+
 int main() {
     testDayEndpoint();
     testWeekEndpoint();
     testMonthEndpoint();
+    testCORSEnabled();
     cout << "API tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- enable default CORS headers in `ApiServer`
- respond to OPTIONS requests for CORS preflight
- add regression test for CORS headers

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841e4bbf11c832a928a557b42609ec5