### PR TITLE
Add recurring event support to CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CXXFLAGS = -std=c++14 -Wall -Iapi -Iexternal/json
 
 # Source files
 SRCS = main.cpp \
-           controller/Controller.cpp \
+	   controller/Controller.cpp \
        model/Model.cpp \
        model/OneTimeEvent.cpp \
        model/RecurringEvent.cpp \
@@ -50,63 +50,74 @@ clean:
 	rm -f $(OBJS) main_mvc.o $(API_TARGET) mvc \
 	$(RECURRENCE_TEST_OBJS) $(EVENT_TEST_OBJS) \
 $(MODEL_TEST_OBJS) $(MODEL_COMPREHENSIVE_TEST_OBJS) \
-$(CONTROLLER_TEST_OBJS) $(TEST_TARGETS)
+$(CONTROLLER_TEST_OBJS) $(VIEW_TEST_OBJS) $(API_TEST_OBJS) $(TEST_TARGETS)
 
 # Test setup
 RECURRENCE_TEST_SRCS = tests/recurrence/recurrence_tests.cpp \
-                       model/recurrence/DailyRecurrence.cpp \
-                       model/recurrence/WeeklyRecurrence.cpp
+	               model/recurrence/DailyRecurrence.cpp \
+	               model/recurrence/WeeklyRecurrence.cpp
 RECURRENCE_TEST_OBJS = $(RECURRENCE_TEST_SRCS:.cpp=.o)
 RECURRENCE_TEST_TARGET = recurrence_tests
 
 EVENT_TEST_SRCS = tests/events/event_tests.cpp \
-                  model/OneTimeEvent.cpp \
-                  model/RecurringEvent.cpp \
-                  model/recurrence/DailyRecurrence.cpp \
-                  model/recurrence/WeeklyRecurrence.cpp
+	          model/OneTimeEvent.cpp \
+	          model/RecurringEvent.cpp \
+	          model/recurrence/DailyRecurrence.cpp \
+	          model/recurrence/WeeklyRecurrence.cpp
 EVENT_TEST_OBJS = $(EVENT_TEST_SRCS:.cpp=.o)
 EVENT_TEST_TARGET = event_tests
 
 MODEL_TEST_SRCS = tests/model/model_tests.cpp \
-                  model/Model.cpp \
-                  model/OneTimeEvent.cpp \
-                  model/RecurringEvent.cpp \
-                  model/recurrence/DailyRecurrence.cpp \
-                  model/recurrence/WeeklyRecurrence.cpp
+	          model/Model.cpp \
+	          model/OneTimeEvent.cpp \
+	          model/RecurringEvent.cpp \
+	          model/recurrence/DailyRecurrence.cpp \
+	          model/recurrence/WeeklyRecurrence.cpp
 MODEL_TEST_OBJS = $(MODEL_TEST_SRCS:.cpp=.o)
 MODEL_TEST_TARGET = model_tests
 
 MODEL_COMPREHENSIVE_TEST_SRCS = tests/model/model_comprehensive_tests.cpp \
-                                model/Model.cpp \
-                                model/OneTimeEvent.cpp \
-                                model/RecurringEvent.cpp \
-                                model/recurrence/DailyRecurrence.cpp \
-                                model/recurrence/WeeklyRecurrence.cpp
+	                        model/Model.cpp \
+	                        model/OneTimeEvent.cpp \
+	                        model/RecurringEvent.cpp \
+	                        model/recurrence/DailyRecurrence.cpp \
+	                        model/recurrence/WeeklyRecurrence.cpp
 MODEL_COMPREHENSIVE_TEST_OBJS = $(MODEL_COMPREHENSIVE_TEST_SRCS:.cpp=.o)
 MODEL_COMPREHENSIVE_TEST_TARGET = model_comprehensive_tests
 
 CONTROLLER_TEST_SRCS = tests/controller/controller_tests.cpp \
-                       controller/Controller.cpp \
-                       model/Model.cpp \
-                       model/OneTimeEvent.cpp \
-                       model/RecurringEvent.cpp \
-                       model/recurrence/DailyRecurrence.cpp \
-                       model/recurrence/WeeklyRecurrence.cpp
+	               controller/Controller.cpp \
+	               model/Model.cpp \
+	               model/OneTimeEvent.cpp \
+	               model/RecurringEvent.cpp \
+	               model/recurrence/DailyRecurrence.cpp \
+	               model/recurrence/WeeklyRecurrence.cpp
 CONTROLLER_TEST_OBJS = $(CONTROLLER_TEST_SRCS:.cpp=.o)
 CONTROLLER_TEST_TARGET = controller_tests
 
+# View tests
+VIEW_TEST_SRCS = tests/view/view_tests.cpp \
+	         view/TextualView.cpp \
+	         model/Model.cpp \
+	         model/OneTimeEvent.cpp \
+	         model/RecurringEvent.cpp \
+	         model/recurrence/DailyRecurrence.cpp \
+	         model/recurrence/WeeklyRecurrence.cpp
+VIEW_TEST_OBJS = $(VIEW_TEST_SRCS:.cpp=.o)
+VIEW_TEST_TARGET = view_tests
+
 # API server tests
 API_TEST_SRCS = tests/api/api_tests.cpp \
-                api/ApiServer.cpp \
-                model/Model.cpp \
-                model/OneTimeEvent.cpp \
-                model/RecurringEvent.cpp \
-                model/recurrence/DailyRecurrence.cpp \
-                model/recurrence/WeeklyRecurrence.cpp
+	        api/ApiServer.cpp \
+	        model/Model.cpp \
+	        model/OneTimeEvent.cpp \
+	        model/RecurringEvent.cpp \
+	        model/recurrence/DailyRecurrence.cpp \
+	        model/recurrence/WeeklyRecurrence.cpp
 API_TEST_OBJS = $(API_TEST_SRCS:.cpp=.o)
 API_TEST_TARGET = api_tests
 
-TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET) $(API_TEST_TARGET)
+TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET) $(VIEW_TEST_TARGET) $(API_TEST_TARGET)
 
 test: $(TEST_TARGETS)
 	./run_all_tests.sh
@@ -124,6 +135,9 @@ $(MODEL_COMPREHENSIVE_TEST_TARGET): $(MODEL_COMPREHENSIVE_TEST_OBJS)
 
 $(CONTROLLER_TEST_TARGET): $(CONTROLLER_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) $(CONTROLLER_TEST_OBJS) -o $@
+
+$(VIEW_TEST_TARGET): $(VIEW_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(VIEW_TEST_OBJS) -o $@
 
 $(API_TEST_TARGET): $(API_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) $(API_TEST_OBJS) -pthread -o $@

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -2,6 +2,9 @@
 #include "Controller.h"
 #include "../model/OneTimeEvent.h"
 #include "../model/RecurringEvent.h"
+#include "../model/recurrence/DailyRecurrence.h"
+#include "../model/recurrence/WeeklyRecurrence.h"
+#include "../utils/WeekDay.h"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -66,7 +69,7 @@ void Controller::run()
     cout << "=== Scheduler CLI ===\n";
     cout << "(All times are entered and displayed in local time,\n"
             " but stored internally in UTC.)\n";
-    cout << "Commands: add  addat  remove  list  next  quit\n";
+    cout << "Commands: add  addat  addrec  remove  list  next  quit\n";
 
     string line;
     while (true)
@@ -131,6 +134,60 @@ void Controller::run()
             model_.addEvent(e);
             cout << "Added event [" << id << "]\n";
         }
+        else if (cmd == "addrec")
+        {
+            string title, desc, timestr, rtype;
+            cout << "Enter title: ";
+            getline(cin, title);
+            cout << "Enter description: ";
+            getline(cin, desc);
+            cout << "Enter start time (YYYY-MM-DD HH:MM): ";
+            getline(cin, timestr);
+            system_clock::time_point start;
+            try
+            {
+                start = parseTimePoint(timestr);
+            }
+            catch (const std::exception &e)
+            {
+                cout << e.what() << "\n";
+                continue;
+            }
+            cout << "Recurrence type (daily/weekly): ";
+            getline(cin, rtype);
+            std::shared_ptr<RecurrencePattern> pat;
+            if (rtype == "weekly" || rtype == "w")
+            {
+                cout << "Interval in weeks: ";
+                int weeks;
+                cin >> weeks;
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
+                cout << "Days of week (0=Sun..6=Sat comma separated): ";
+                string daysStr;
+                getline(cin, daysStr);
+                vector<Weekday> days;
+                string tmp;
+                istringstream ds(daysStr);
+                while (getline(ds, tmp, ','))
+                {
+                    int d = stoi(tmp);
+                    days.push_back(static_cast<Weekday>(d));
+                }
+                pat = make_shared<WeeklyRecurrence>(start, days, weeks);
+            }
+            else
+            {
+                cout << "Interval in days: ";
+                int days;
+                cin >> days;
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
+                pat = make_shared<DailyRecurrence>(start, days);
+            }
+
+            system_clock::duration dur = hours(1);
+            string id = addRecurringEvent(title, desc, start, dur, pat);
+            cout << "Added recurring event [" << id << "]\n";
+        }
         else if (cmd == "remove")
         {
             cout << "Enter event ID to remove: ";
@@ -159,7 +216,7 @@ void Controller::run()
         }
         else
         {
-            cout << "Unknown command. Available: add  addat  remove  list  next  quit\n";
+            cout << "Unknown command. Available: add  addat  addrec  remove  list  next  quit\n";
         }
     }
 

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -10,6 +10,7 @@
   Controller coordinates a Model and a View.  It runs a simple CLI loop:
     - "add" prompts for title, description, and hours-from-now → adds OneTimeEvent with an auto-generated ID.
     - "addat" prompts for title, description, and timestamp → adds OneTimeEvent at a specific time with an auto-generated ID.
+    - "addrec" prompts for recurrence details → adds a RecurringEvent.
     - "remove" prompts for ID → removes that event.
     - "list" → asks View to render current Model state.
     - "next" → prints the next upcoming event.

--- a/model/Event.h
+++ b/model/Event.h
@@ -13,11 +13,12 @@ protected:
     // Stored in UTC regardless of the user's local timezone
     chrono::system_clock::time_point timeUtc;
     chrono::system_clock::duration duration;
+    bool recurringFlag;
 
 public:
     Event(const string &id, const string &desc, const string &title, chrono::system_clock::time_point time,
           chrono::system_clock::duration duration)
-        : id(id), description(desc), title(title), timeUtc(time), duration(duration) {}
+        : id(id), description(desc), title(title), timeUtc(time), duration(duration), recurringFlag(false) {}
     virtual ~Event() = default;
     virtual std::unique_ptr<Event> clone() const { return std::make_unique<Event>(*this); }
     // Returned value is in UTC
@@ -26,4 +27,7 @@ public:
     string getId() const { return id; }
     string getDescription() const { return description; }
     string getTitle() const { return title; }
+    bool isRecurring() const { return recurringFlag; }
+protected:
+    void setRecurring(bool r) { recurringFlag = r; }
 };

--- a/model/RecurringEvent.cpp
+++ b/model/RecurringEvent.cpp
@@ -7,6 +7,7 @@ RecurringEvent::RecurringEvent(const string &id, const string &desc,
                                std::shared_ptr<RecurrencePattern> recurrencePattern)
     : Event(id, desc, title, time, duration), recurrencePattern(std::move(recurrencePattern))
 {
+    setRecurring(true);
 }
 
 bool RecurringEvent::isDueOn(chrono::system_clock::time_point data) const

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 # Build all test executables
-make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests api_tests
+make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests
 
 # Run each test executable sequentially
-for t in recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests api_tests; do
+for t in recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests; do
     echo "Running $t"
     ./$t
     echo

--- a/tests/view/view_tests.cpp
+++ b/tests/view/view_tests.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+#include <sstream>
+#include "../../model/Model.h"
+#include "../../model/OneTimeEvent.h"
+#include "../../model/RecurringEvent.h"
+#include "../../model/recurrence/DailyRecurrence.h"
+#include "../../view/TextualView.h"
+#include "../test_utils.h"
+#include <memory>
+
+using namespace std;
+using namespace chrono;
+
+static void testViewShowsRecurringFlag()
+{
+    Model m;
+    OneTimeEvent o("O","d","t", makeTime(2025,6,1,9), hours(1));
+    auto start = makeTime(2025,6,2,9);
+    auto pat = make_shared<DailyRecurrence>(start, 1);
+    RecurringEvent r("R","d","t", start, hours(1), pat);
+    m.addEvent(o);
+    m.addEvent(r);
+    TextualView v(m);
+    stringstream ss;
+    auto old = cout.rdbuf(ss.rdbuf());
+    v.render();
+    cout.rdbuf(old);
+    string out = ss.str();
+    assert(out.find("(recurring)") != string::npos);
+}
+
+int main()
+{
+    testViewShowsRecurringFlag();
+    cout << "View tests passed\n";
+    return 0;
+}

--- a/view/TextualView.cpp
+++ b/view/TextualView.cpp
@@ -34,6 +34,10 @@ void TextualView::render()
         strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &tm_buf);
 
         std::cout << "[" << e.getId() << "] \""
-                  << e.getTitle() << "\" @ " << buf << "\n";
+                  << e.getTitle() << "\" @ " << buf;
+        if (e.isRecurring())
+            std::cout << " (recurring)";
+        std::cout << "\n";
     }
 }
+


### PR DESCRIPTION
## Summary
- add recurring flag to `Event`
- show recurring events in `TextualView`
- implement `addrec` command in `Controller` for CLI recurring events
- test view output for recurring indicator
- extend Makefile and test runner for new view tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845f111e4c8832abe15757cdac609fe