### PR TITLE
Add schedule views and command map

### DIFF
--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -36,6 +36,12 @@ private:
     static std::chrono::system_clock::time_point
     parseTimePoint(const std::string &timestamp);
 
+    static std::chrono::system_clock::time_point
+    parseDate(const std::string &dateStr);
+
+    static std::chrono::system_clock::time_point
+    parseMonth(const std::string &monthStr);
+
     // Print the next upcoming event or “no upcoming events”.
     void printNextEvent();
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -25,6 +25,7 @@ class StubView : public View
 public:
     explicit StubView(const ReadOnlyModel &m) : View(m) {}
     void render() override {}
+    void renderEvents(const std::vector<Event>&) override {}
 };
 
 class FakePattern : public RecurrencePattern

--- a/tests/view/view_tests.cpp
+++ b/tests/view/view_tests.cpp
@@ -29,9 +29,25 @@ static void testViewShowsRecurringFlag()
     assert(out.find("(recurring)") != string::npos);
 }
 
+static void testRenderEventsList()
+{
+    Model m;
+    OneTimeEvent o("1","d","t", makeTime(2025,6,1,9), hours(1));
+    m.addEvent(o);
+    TextualView v(m);
+    auto list = m.getEventsOnDay(makeTime(2025,6,1,0));
+    stringstream ss;
+    auto old = cout.rdbuf(ss.rdbuf());
+    v.renderEvents(list);
+    cout.rdbuf(old);
+    string out = ss.str();
+    assert(out.find("[1]") != string::npos);
+}
+
 int main()
 {
     testViewShowsRecurringFlag();
+    testRenderEventsList();
     cout << "View tests passed\n";
     return 0;
 }

--- a/view/TextualView.cpp
+++ b/view/TextualView.cpp
@@ -13,7 +13,11 @@ void TextualView::render()
     // Fetch “everything” by using a far‑future cutoff.
     auto farFuture = std::chrono::system_clock::now() + std::chrono::hours(24 * 365);
     auto events = model_.getEvents(-1, farFuture);
+    renderEvents(events);
+}
 
+void TextualView::renderEvents(const std::vector<Event> &events)
+{
     if (events.empty())
     {
         std::cout << "(no scheduled events)\n";

--- a/view/TextualView.h
+++ b/view/TextualView.h
@@ -17,4 +17,7 @@ public:
 
     // Override: fetch from model_ and print all events
     void render() override;
+
+    // Print a provided list of events
+    void renderEvents(const std::vector<Event> &events) override;
 };

--- a/view/View.h
+++ b/view/View.h
@@ -27,4 +27,7 @@ public:
     // Every concrete View must implement this method.
     // It should pull events from model_ and display them.
     virtual void render() = 0;
+
+    // Display the provided list of events.
+    virtual void renderEvents(const std::vector<Event> &events) = 0;
 };


### PR DESCRIPTION
## Summary
- enable rendering arbitrary event lists via `renderEvents`
- map CLI commands in `Controller` for extensibility
- support viewing schedules by day, week, month and next N events
- update tests for new view interface

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845f48e3520832aadca59a77d2d207d