### PR TITLE
Fix recurring event next time

### DIFF
--- a/model/RecurringEvent.h
+++ b/model/RecurringEvent.h
@@ -16,5 +16,6 @@ public:
     vector<chrono::system_clock::time_point> getNextNOccurrences(chrono::system_clock::time_point after,
                                                                  int n) const;
     bool isDueOn(chrono::system_clock::time_point date) const;
+    std::shared_ptr<RecurrencePattern> getRecurrencePattern() const { return recurrencePattern; }
     std::unique_ptr<Event> clone() const override { return std::make_unique<RecurringEvent>(*this); }
 };


### PR DESCRIPTION
## Summary
- expose recurrence pattern from `RecurringEvent`
- compute the earliest occurrence for recurring events when fetching next event

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845f6f58b50832a93681b70f1321df2