### PR TITLE
Handle recurring events in next commands

### DIFF
--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -185,8 +185,7 @@ void Controller::run()
     commands["nextn"] = [&]() {
         cout << "Enter number of events: ";
         int n; cin >> n; cin.ignore(numeric_limits<streamsize>::max(), '\n');
-        auto end = system_clock::now() + hours(24*365);
-        auto evs = model_.getEvents(n, end);
+        auto evs = model_.getNextNEvents(n);
         view_.renderEvents(evs);
     };
 

--- a/model/Model.h
+++ b/model/Model.h
@@ -34,6 +34,8 @@ public:
               std::chrono::system_clock::time_point endDate) const override;
 
     Event getNextEvent() const override;
+    // Return the next n upcoming event occurrences expanding recurring events.
+    std::vector<Event> getNextNEvents(int n) const;
 
     // Additional query methods
     std::vector<Event> getEventsOnDay(std::chrono::system_clock::time_point day) const;

--- a/tests/model/model_tests.cpp
+++ b/tests/model/model_tests.cpp
@@ -74,6 +74,26 @@ static void testModelWithDailyRecurring()
     assert(evs[1].getId() == "O");
 }
 
+static void testNextNWithRecurring()
+{
+    Model m;
+    auto start = makeTime(2025,6,1,8);
+    auto rec = std::make_shared<DailyRecurrence>(start, 1);
+    RecurringEvent wake("W","wake","Wake", start, hours(1), rec);
+    OneTimeEvent ball("B","play","Ball", makeTime(2025,6,5,12), hours(2));
+    m.addEvent(wake);
+    m.addEvent(ball);
+
+    auto next = m.getNextEvent();
+    assert(next.getId() == "W");
+
+    auto list = m.getNextNEvents(6);
+    assert(list.size() == 6);
+    for(int i=0;i<5;i++)
+        assert(list[i].getTime() == start + hours(24*i));
+    assert(list[5].getId() == "B");
+}
+
 static void testEventsOnDay()
 {
     Model m;
@@ -143,6 +163,7 @@ int main()
     testModelRemove();
     testModelGetEventsLimit();
     testModelWithDailyRecurring();
+    testNextNWithRecurring();
     testEventsOnDay();
     testEventsInWeek();
     testEventsInMonth();


### PR DESCRIPTION
## Summary
- add `getNextNEvents` helper to expand recurring occurrences
- use helper in `getNextEvent` and controller `nextn` command
- test recurring handling with new `testNextNWithRecurring`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845fa0be1e0832aabc69622ff22e16f