### PR TITLE
Fix recurring event persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,17 @@ API_TEST_SRCS = tests/api/api_tests.cpp \
 API_TEST_OBJS = $(API_TEST_SRCS:.cpp=.o)
 API_TEST_TARGET = api_tests
 
-TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET) $(VIEW_TEST_TARGET) $(API_TEST_TARGET)
+DATABASE_TEST_SRCS = tests/database/database_tests.cpp \
+                     database/SQLiteScheduleDatabase.cpp \
+                     model/Model.cpp \
+                     model/OneTimeEvent.cpp \
+                     model/RecurringEvent.cpp \
+                     model/recurrence/DailyRecurrence.cpp \
+                     model/recurrence/WeeklyRecurrence.cpp
+DATABASE_TEST_OBJS = $(DATABASE_TEST_SRCS:.cpp=.o)
+DATABASE_TEST_TARGET = database_tests
+
+TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET) $(VIEW_TEST_TARGET) $(API_TEST_TARGET) $(DATABASE_TEST_TARGET)
 
 test: $(TEST_TARGETS)
 	./run_all_tests.sh
@@ -141,5 +151,8 @@ $(VIEW_TEST_TARGET): $(VIEW_TEST_OBJS)
 
 $(API_TEST_TARGET): $(API_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) $(API_TEST_OBJS) -pthread -o $@
+
+$(DATABASE_TEST_TARGET): $(DATABASE_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(DATABASE_TEST_OBJS) -lsqlite3 -o $@
 
 .PHONY: test

--- a/database/IScheduleDatabase.h
+++ b/database/IScheduleDatabase.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <memory>
 #include "../model/Event.h"
 
 class IScheduleDatabase {
@@ -10,5 +11,5 @@ public:
 
     virtual bool addEvent(const Event &e) = 0;
     virtual bool removeEvent(const std::string &id) = 0;
-    virtual std::vector<Event> getAllEvents() const = 0;
+    virtual std::vector<std::unique_ptr<Event>> getAllEvents() const = 0;
 };

--- a/database/SQLiteScheduleDatabase.h
+++ b/database/SQLiteScheduleDatabase.h
@@ -12,7 +12,7 @@ public:
 
     bool addEvent(const Event &e) override;
     bool removeEvent(const std::string &id) override;
-    std::vector<Event> getAllEvents() const override;
+    std::vector<std::unique_ptr<Event>> getAllEvents() const override;
 
 private:
     std::unique_ptr<sqlite3, decltype(&sqlite3_close)> db_;

--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -44,9 +44,9 @@ Model::Model(IScheduleDatabase *db)
     if (db_)
     {
         auto loaded = db_->getAllEvents();
-        for (const auto &e : loaded)
+        for (auto &e : loaded)
         {
-            events.push_back(e.clone());
+            events.push_back(std::move(e));
         }
     }
     sortEvents();

--- a/model/recurrence/DailyRecurrence.h
+++ b/model/recurrence/DailyRecurrence.h
@@ -1,6 +1,7 @@
 #include "RecurrencePattern.h"
 #include <chrono>
 #include <vector>
+#include <string>
 
 // This pattern handles the "Every x days" recurrence
 // Example: every 7 days I want to order Nandos.
@@ -23,6 +24,11 @@ public:
         chrono::system_clock::time_point after, int n) const override;
 
     bool isDueOn(chrono::system_clock::time_point date) const override;
+
+    std::string type() const override { return "daily"; }
+    int getInterval() const { return repeatingInterval; }
+    int getMaxOccurrences() const { return maxOccurrences; }
+    chrono::system_clock::time_point getEndDate() const { return endDate; }
 
     ~DailyRecurrence() override = default;
 };

--- a/model/recurrence/RecurrencePattern.h
+++ b/model/recurrence/RecurrencePattern.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <chrono>
+#include <string>
 using namespace std;
 
 // This is a recurrence pattern which the RecurringEvent will be composed with.
@@ -11,5 +12,6 @@ public:
     virtual vector<chrono::system_clock::time_point> getNextNOccurrences(chrono::system_clock::time_point after,
                                                                          int n) const = 0;
     virtual bool isDueOn(chrono::system_clock::time_point date) const = 0;
+    virtual std::string type() const = 0;
     virtual ~RecurrencePattern() = default;
 };

--- a/model/recurrence/WeeklyRecurrence.h
+++ b/model/recurrence/WeeklyRecurrence.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <chrono>
 #include <algorithm>
+#include <string>
 #include "../../utils/WeekDay.h"
 // This pattern handles the every x weeks on yDay and zDay walk the dalk.
 // For example, every week on Tuesday and Thursday, I have Object Oriented Design Class.
@@ -26,6 +27,12 @@ public:
         chrono::system_clock::time_point after, int n) const override;
 
     bool isDueOn(chrono::system_clock::time_point date) const override;
+
+    std::string type() const override { return "weekly"; }
+    int getInterval() const { return repeatingInterval; }
+    const std::vector<Weekday> &getDaysOfWeek() const { return daysOfTheWeek; }
+    int getMaxOccurrences() const { return maxOccurrences; }
+    chrono::system_clock::time_point getEndDate() const { return endDate; }
 
     ~WeeklyRecurrence() override = default;
 };

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 # Build all test executables
-make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests
+make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests
 
 # Run each test executable sequentially
-for t in recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests; do
+for t in recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests; do
     echo "Running $t"
     ./$t
     echo

--- a/tests/database/database_tests.cpp
+++ b/tests/database/database_tests.cpp
@@ -1,0 +1,42 @@
+#include <cassert>
+#include <cstdio>
+#include <memory>
+#include "../../database/SQLiteScheduleDatabase.h"
+#include "../../model/Model.h"
+#include "../../model/RecurringEvent.h"
+#include "../../model/recurrence/DailyRecurrence.h"
+#include "../test_utils.h"
+#include <iostream>
+
+using namespace std;
+using namespace chrono;
+
+static void testRecurringPersistence() {
+    const char* path = "test_persist.db";
+    std::remove(path);
+    {
+        SQLiteScheduleDatabase db(path);
+        Model m(&db);
+        auto start = makeTime(2025,6,9,8);
+        auto pat = std::make_shared<DailyRecurrence>(start,1);
+        RecurringEvent r("R","d","t", start, hours(1), pat);
+        m.addEvent(r);
+    }
+    {
+        SQLiteScheduleDatabase db(path);
+        Model m(&db);
+        auto events = m.getNextNEvents(3);
+        assert(events.size() == 3);
+        for(int i=0;i<3;i++) {
+            assert(events[i].getId() == "R");
+            assert(events[i].isRecurring());
+        }
+    }
+    std::remove(path);
+}
+
+int main() {
+    testRecurringPersistence();
+    cout << "Database tests passed\n";
+    return 0;
+}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -47,4 +47,6 @@ public:
         isDueCalled = true;
         return dueResult;
     }
+
+    std::string type() const override { return "fake"; }
 };


### PR DESCRIPTION
## Summary
- store recurrence data in the SQLite DB
- load recurring events from DB using saved pattern info
- expose recurrence info via new getters
- add database regression test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845ff65f6d4832ab43ff310cf060e9e