### PR TITLE
Ensure DB persistence for recurring events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Summary:
 ## Running Tests
 
 Use `make test` or run the `./run_all_tests.sh` script to build and execute all unit tests.
+
+## Database Persistence
+
+Events are stored in an SQLite database (`events.db`). On startup the model
+loads all events from this database, reconstructing recurring patterns so
+commands like `list` and `nextn` work across restarts. The database tests in
+`tests/database` verify this behavior.

--- a/tests/database/database_tests.cpp
+++ b/tests/database/database_tests.cpp
@@ -4,9 +4,12 @@
 #include "../../database/SQLiteScheduleDatabase.h"
 #include "../../model/Model.h"
 #include "../../model/RecurringEvent.h"
+#include "../../model/OneTimeEvent.h"
 #include "../../model/recurrence/DailyRecurrence.h"
+#include "../../model/recurrence/WeeklyRecurrence.h"
 #include "../test_utils.h"
 #include <iostream>
+#include <sqlite3.h>
 
 using namespace std;
 using namespace chrono;
@@ -32,11 +35,84 @@ static void testRecurringPersistence() {
             assert(events[i].isRecurring());
         }
     }
+    // ensure only one row stored
+    std::unique_ptr<sqlite3, decltype(&sqlite3_close)> conn(nullptr, sqlite3_close);
+    sqlite3* rawConn = nullptr;
+    if (sqlite3_open(path, &rawConn) != SQLITE_OK) {
+        assert(false && "failed to open db");
+    }
+    conn.reset(rawConn);
+    sqlite3_stmt* st = nullptr;
+    sqlite3_prepare_v2(conn.get(), "SELECT COUNT(*) FROM events", -1, &st, nullptr);
+    int rows = 0;
+    if(sqlite3_step(st) == SQLITE_ROW) rows = sqlite3_column_int(st, 0);
+    sqlite3_finalize(st);
+    assert(rows==1);
+    std::remove(path);
+}
+
+static void testOneTimePersistence() {
+    const char* path = "test_persist.db";
+    std::remove(path);
+    {
+        SQLiteScheduleDatabase db(path);
+        Model m(&db);
+        auto time = makeTime(2025,6,10,12);
+        OneTimeEvent e("O","desc","title", time, hours(1));
+        m.addEvent(e);
+    }
+    {
+        SQLiteScheduleDatabase db(path);
+        Model m(&db);
+        auto events = m.getNextNEvents(1);
+        assert(events.size() == 1);
+        assert(events[0].getId()=="O");
+        assert(!events[0].isRecurring());
+    }
+    std::remove(path);
+}
+
+static void testWeeklyPersistence() {
+    const char* path = "test_persist.db";
+    std::remove(path);
+    {
+        SQLiteScheduleDatabase db(path);
+        Model m(&db);
+        auto start = makeTime(2025,6,9,9); // Monday 9 AM
+        std::vector<Weekday> days{Weekday::Monday, Weekday::Wednesday};
+        auto pat = std::make_shared<WeeklyRecurrence>(start, days, 1);
+        RecurringEvent r("W","desc","title", start, hours(1), pat);
+        m.addEvent(r);
+    }
+    {
+        SQLiteScheduleDatabase db(path);
+        Model m(&db);
+        auto events = m.getNextNEvents(4);
+        assert(events.size() == 4);
+        for(const auto& e : events) {
+            assert(e.getId() == "W");
+            assert(e.isRecurring());
+        }
+    }
+    std::unique_ptr<sqlite3, decltype(&sqlite3_close)> conn(nullptr, sqlite3_close);
+    sqlite3* raw = nullptr;
+    if (sqlite3_open(path, &raw) != SQLITE_OK) {
+        assert(false && "failed to open db");
+    }
+    conn.reset(raw);
+    sqlite3_stmt* st = nullptr;
+    sqlite3_prepare_v2(conn.get(), "SELECT COUNT(*) FROM events", -1, &st, nullptr);
+    int rows = 0;
+    if (sqlite3_step(st) == SQLITE_ROW) rows = sqlite3_column_int(st, 0);
+    sqlite3_finalize(st);
+    assert(rows == 1);
     std::remove(path);
 }
 
 int main() {
     testRecurringPersistence();
+    testOneTimePersistence();
+    testWeeklyPersistence();
     cout << "Database tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- add explicit weekly recurrence persistence test
- document SQLite event storage and automatic reload on startup

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684602f9824c832a88966cbecd4687b0