### PR TITLE
Fix timezone handling for day/week/month queries

### DIFF
--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -168,29 +168,30 @@ bool Model::removeEvent(const std::string &id)
     return removed;
 }
 
-static std::chrono::system_clock::time_point startOfDay(std::chrono::system_clock::time_point tp)
+// Return the start of the day in the user's local time zone
+static std::chrono::system_clock::time_point startOfLocalDay(std::chrono::system_clock::time_point tp)
 {
     time_t t = std::chrono::system_clock::to_time_t(tp);
     std::tm tm_buf;
 #if defined(_MSC_VER)
-    gmtime_s(&tm_buf, &t);
+    localtime_s(&tm_buf, &t);
 #else
-    gmtime_r(&t, &tm_buf);
+    localtime_r(&t, &tm_buf);
 #endif
     tm_buf.tm_hour = 0;
     tm_buf.tm_min = 0;
     tm_buf.tm_sec = 0;
 #if defined(_MSC_VER)
-    time_t start_t = _mkgmtime(&tm_buf);
+    time_t start_t = mktime(&tm_buf);
 #else
-    time_t start_t = timegm(&tm_buf);
+    time_t start_t = mktime(&tm_buf);
 #endif
     return std::chrono::system_clock::from_time_t(start_t);
 }
 
 std::vector<Event> Model::getEventsOnDay(std::chrono::system_clock::time_point day) const
 {
-    auto start = startOfDay(day);
+    auto start = startOfLocalDay(day);
     auto end = start + std::chrono::hours(24);
     std::vector<Event> result;
     std::lock_guard<std::mutex> lock(mutex_);
@@ -211,13 +212,13 @@ std::vector<Event> Model::getEventsInWeek(std::chrono::system_clock::time_point 
     time_t t = std::chrono::system_clock::to_time_t(day);
     std::tm tm_buf;
 #if defined(_MSC_VER)
-    gmtime_s(&tm_buf, &t);
+    localtime_s(&tm_buf, &t);
 #else
-    gmtime_r(&t, &tm_buf);
+    localtime_r(&t, &tm_buf);
 #endif
     int wday = tm_buf.tm_wday; // 0=Sunday
     int diff = (wday + 6) % 7; // days since Monday
-    auto start = startOfDay(day) - std::chrono::hours(24 * diff);
+    auto start = startOfLocalDay(day) - std::chrono::hours(24 * diff);
     auto end = start + std::chrono::hours(24 * 7);
     std::vector<Event> result;
     std::lock_guard<std::mutex> lock(mutex_);
@@ -238,25 +239,25 @@ std::vector<Event> Model::getEventsInMonth(std::chrono::system_clock::time_point
     time_t t = std::chrono::system_clock::to_time_t(day);
     std::tm tm_buf;
 #if defined(_MSC_VER)
-    gmtime_s(&tm_buf, &t);
+    localtime_s(&tm_buf, &t);
 #else
-    gmtime_r(&t, &tm_buf);
+    localtime_r(&t, &tm_buf);
 #endif
     tm_buf.tm_mday = 1;
     tm_buf.tm_hour = 0;
     tm_buf.tm_min = 0;
     tm_buf.tm_sec = 0;
 #if defined(_MSC_VER)
-    time_t start_t = _mkgmtime(&tm_buf);
+    time_t start_t = mktime(&tm_buf);
 #else
-    time_t start_t = timegm(&tm_buf);
+    time_t start_t = mktime(&tm_buf);
 #endif
     auto start = std::chrono::system_clock::from_time_t(start_t);
     tm_buf.tm_mon += 1;
 #if defined(_MSC_VER)
-    time_t end_t = _mkgmtime(&tm_buf);
+    time_t end_t = mktime(&tm_buf);
 #else
-    time_t end_t = timegm(&tm_buf);
+    time_t end_t = mktime(&tm_buf);
 #endif
     auto end = std::chrono::system_clock::from_time_t(end_t);
 


### PR DESCRIPTION
## Summary
- ensure date range calculations use local time
- update test to verify timezone-aware queries

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684613e439f0832a97f8e86537811c7d