### PR TITLE
Modernize time handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Compiler and flags
 CXX      = g++
-CXXFLAGS = -std=c++14 -Wall -Iapi -Iexternal/json
+CXXFLAGS = -std=c++20 -Wall -Iapi -Iexternal/json
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ All event timestamps are stored internally in UTC to ensure consistent
 behavior across time zones. When interacting with the CLI you provide and
 view times in your **local time zone**. The scheduler converts local input
 times to UTC for storage and converts them back to local time when events
-are displayed.
+are displayed. Time conversions now rely on the C++20 `<chrono>` timezone
+library which correctly handles daylight-saving transitions.
 
 Summary:
 - **Input and output:** local time

--- a/model/recurrence/WeeklyRecurrence.cpp
+++ b/model/recurrence/WeeklyRecurrence.cpp
@@ -1,19 +1,17 @@
 #include "WeeklyRecurrence.h"
 #include "../../utils/WeekDay.h"
 #include <algorithm>
+#include <chrono>
 
 namespace
 {
 Weekday weekdayFromTimePoint(chrono::system_clock::time_point tp)
 {
-    time_t t_c = chrono::system_clock::to_time_t(tp);
-    tm tm_buf;
-#if defined(_MSC_VER)
-    localtime_s(&tm_buf, &t_c);
-#else
-    localtime_r(&t_c, &tm_buf);
-#endif
-    return static_cast<Weekday>(tm_buf.tm_wday);
+    using namespace chrono;
+    auto z = current_zone();
+    zoned_time zt{z, tp};
+    weekday wd{floor<days>(zt.get_local_time())};
+    return static_cast<Weekday>(wd.c_encoding());
 }
 }
 

--- a/view/TextualView.cpp
+++ b/view/TextualView.cpp
@@ -1,5 +1,5 @@
 #include "TextualView.h"
-#include <iomanip>
+#include <format>
 
 TextualView::TextualView(const ReadOnlyModel &model)
     : View(model)
@@ -26,19 +26,12 @@ void TextualView::renderEvents(const std::vector<Event> &events)
 
     for (const auto &e : events)
     {
-        auto tp = e.getTime();
-        std::time_t t_c = std::chrono::system_clock::to_time_t(tp);
-        std::tm tm_buf;
-#if defined(_MSC_VER)
-        localtime_s(&tm_buf, &t_c);
-#else
-        localtime_r(&t_c, &tm_buf);
-#endif
-        char buf[32];
-        strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &tm_buf);
+        auto z = std::chrono::current_zone();
+        std::chrono::zoned_time zt{z, e.getTime()};
+        auto timeStr = std::format("{:%Y-%m-%d %H:%M}", zt);
 
         std::cout << "[" << e.getId() << "] \""
-                  << e.getTitle() << "\" @ " << buf;
+                  << e.getTitle() << "\" @ " << timeStr;
         if (e.isRecurring())
             std::cout << " (recurring)";
         std::cout << "\n";


### PR DESCRIPTION
## Summary
- build with C++20
- format and parse times with C++20 chrono time‑zone API
- update textual view to use chrono formatting
- compute weekdays using chrono
- document chrono usage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68461811933c832a95a30344f54b0885