### PR TITLE
Add active event loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Compiler and flags
 CXX      = g++
-CXXFLAGS = -std=c++14 -Wall -Iapi -Iexternal/json
+CXXFLAGS = -std=c++14 -Wall -Iapi -Iexternal/json -Ischeduler
 
 
 
@@ -16,7 +16,8 @@ SRCS = main.cpp \
        model/recurrence/YearlyRecurrence.cpp \
        view/TextualView.cpp \
        api/ApiServer.cpp \
-       database/SQLiteScheduleDatabase.cpp
+       database/SQLiteScheduleDatabase.cpp \
+       scheduler/EventLoop.cpp
 
 # Object files (replace .cpp with .o)
 OBJS = $(SRCS:.cpp=.o)

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Events are stored in an SQLite database (`events.db`). On startup the model
 loads all events from this database, reconstructing recurring patterns so
 commands like `list` and `nextn` work across restarts. The database tests in
 `tests/database` verify this behavior.
+
+## Event Loop
+
+The scheduler now includes an active `EventLoop` component. Tasks derived from
+`Event` (for example `ScheduledTask`) can register notification and execution
+callbacks. The loop runs in a background thread, dispatching notifications a
+few minutes before each task executes and invoking the task's action at the
+scheduled time.

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include "model/Model.h"
 #include "database/SQLiteScheduleDatabase.h"
 #include "api/ApiServer.h"
+#include "scheduler/EventLoop.h"
 #include <vector>
 
 int main()
@@ -10,9 +11,14 @@ int main()
     SQLiteScheduleDatabase db("events.db");
     Model model(&db);
 
+    EventLoop loop(model);
+    loop.start();
+
     // Start the HTTP API server
     ApiServer api(model);
     api.start();
+
+    loop.stop();
 
     return 0;
 }

--- a/model/Event.h
+++ b/model/Event.h
@@ -21,6 +21,12 @@ public:
         : id(id), description(desc), title(title), timeUtc(time), duration(duration), recurringFlag(false) {}
     virtual ~Event() = default;
     virtual std::unique_ptr<Event> clone() const { return std::make_unique<Event>(*this); }
+
+    // Called some minutes before the scheduled time. Default does nothing.
+    virtual void notify() {}
+
+    // Called when the scheduled time arrives. Default does nothing.
+    virtual void execute() {}
     // Returned value is in UTC
     chrono::system_clock::time_point getTime() const { return timeUtc; }
     chrono::system_clock::duration getDuration() const { return duration; }

--- a/scheduler/EventLoop.cpp
+++ b/scheduler/EventLoop.cpp
@@ -1,0 +1,65 @@
+#include "EventLoop.h"
+#include <algorithm>
+
+EventLoop::EventLoop(Model &m) : model_(m) {}
+
+EventLoop::~EventLoop() { stop(); }
+
+void EventLoop::start() {
+    if (running_) return;
+    running_ = true;
+    worker_ = std::thread(&EventLoop::threadFunc, this);
+}
+
+void EventLoop::stop() {
+    if (!running_) return;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        running_ = false;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) worker_.join();
+}
+
+void EventLoop::addTask(const std::shared_ptr<ScheduledTask> &task) {
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        queue_.push(task);
+    }
+    cv_.notify_one();
+    model_.addEvent(*task);
+}
+
+void EventLoop::threadFunc() {
+    std::unique_lock<std::mutex> lock(mtx_);
+    while (running_) {
+        if (queue_.empty()) {
+            cv_.wait(lock, [&]{ return !running_ || !queue_.empty(); });
+            if (!running_) break;
+        }
+
+        auto next = queue_.top();
+        auto now = std::chrono::system_clock::now();
+
+        if (!next->notified() && now >= next->getNotifyTime()) {
+            lock.unlock();
+            next->notify();
+            lock.lock();
+            next->setNotified(true);
+            continue;
+        }
+
+        if (now >= next->getTime()) {
+            queue_.pop();
+            lock.unlock();
+            next->execute();
+            model_.removeEvent(next->getId());
+            lock.lock();
+            continue;
+        }
+
+        auto wake = next->notified() ? next->getTime()
+                                     : std::min(next->getNotifyTime(), next->getTime());
+        cv_.wait_until(lock, wake);
+    }
+}

--- a/scheduler/EventLoop.h
+++ b/scheduler/EventLoop.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "ScheduledTask.h"
+#include "../model/Model.h"
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <atomic>
+
+class EventLoop {
+    struct Compare {
+        bool operator()(const std::shared_ptr<ScheduledTask> &a,
+                        const std::shared_ptr<ScheduledTask> &b) const {
+            return a->getTime() > b->getTime();
+        }
+    };
+
+    Model &model_;
+    std::priority_queue<std::shared_ptr<ScheduledTask>,
+                        std::vector<std::shared_ptr<ScheduledTask>>, Compare>
+        queue_;
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    std::thread worker_;
+    std::atomic<bool> running_{false};
+
+    void threadFunc();
+
+public:
+    explicit EventLoop(Model &m);
+    ~EventLoop();
+
+    void start();
+    void stop();
+    void addTask(const std::shared_ptr<ScheduledTask> &task);
+};

--- a/scheduler/ScheduledTask.h
+++ b/scheduler/ScheduledTask.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "../model/Event.h"
+#include <functional>
+#include <chrono>
+#include <memory>
+
+class ScheduledTask : public Event {
+    std::function<void()> notifyCb_;
+    std::function<void()> actionCb_;
+    std::chrono::system_clock::time_point notifyTime_;
+    bool notified_ = false;
+
+public:
+    ScheduledTask(const std::string &id,
+                  const std::string &desc,
+                  const std::string &title,
+                  std::chrono::system_clock::time_point time,
+                  std::chrono::system_clock::duration dur,
+                  std::chrono::system_clock::duration notifyBefore,
+                  std::function<void()> notifyCb,
+                  std::function<void()> actionCb)
+        : Event(id, desc, title, time, dur),
+          notifyCb_(std::move(notifyCb)),
+          actionCb_(std::move(actionCb)) {
+        notifyTime_ = timeUtc - notifyBefore;
+    }
+
+    std::unique_ptr<Event> clone() const override { return std::make_unique<ScheduledTask>(*this); }
+
+    void notify() override { if (notifyCb_) notifyCb_(); }
+
+    void execute() override { if (actionCb_) actionCb_(); }
+
+    std::chrono::system_clock::time_point getNotifyTime() const { return notifyTime_; }
+    bool notified() const { return notified_; }
+    void setNotified(bool v) { notified_ = v; }
+};


### PR DESCRIPTION
## Summary
- add notify/execute hooks in `Event`
- implement `ScheduledTask` and threaded `EventLoop`
- integrate event loop in `main`
- document event loop in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68463562647c832ab28ec36eb67c2354