### PR TITLE
Add custom notification timing and callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,22 @@ The scheduler now includes an active `EventLoop` component. Tasks derived from
 callbacks. The loop runs in a background thread, dispatching notifications a
 few minutes before each task executes and invoking the task's action at the
 scheduled time.
+
+## Customising Notifications and Actions
+
+`ScheduledTask` allows full control over when notifications occur and what
+happens when a task runs. You can supply your own callback functions – perfect
+for triggering web requests, talking to a Raspberry Pi or scraping a website.
+
+```cpp
+// Notify 5 minutes before and call a custom action
+ScheduledTask task(
+    "abc", "demo", "Demo Task", when,
+    std::chrono::hours(1), std::chrono::minutes(5),
+    []{ std::cout << "ring ring"; },
+    []{ runMyScript(); });
+```
+
+Alternatively an absolute notification time can be provided. `Controller`
+exposes `scheduleTask` so CLI or agent code can enqueue tasks with different
+callbacks or lead times.

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -7,6 +7,7 @@
 #include "../view/View.h"
 #include "../scheduler/EventLoop.h"
 #include <chrono>
+#include <functional>
 
 /*
   Controller coordinates a Model and a View.  It runs a simple CLI loop:
@@ -60,7 +61,11 @@ private:
     // Print the next upcoming event or “no upcoming events”.
     void printNextEvent();
 
-    void scheduleTask(const Event &e);
+    void scheduleTask(const Event &e,
+                      std::chrono::system_clock::duration notifyBefore =
+                          std::chrono::minutes(10),
+                      std::function<void()> notifyCb = {},
+                      std::function<void()> actionCb = {});
 
     // Add a recurring event using an existing RecurrencePattern. Returns the ID of the new event.
     std::string addRecurringEvent(const std::string &title,

--- a/main_mvc.cpp
+++ b/main_mvc.cpp
@@ -3,7 +3,6 @@
 #include "model/Model.h"
 #include "database/SQLiteScheduleDatabase.h"
 #include "scheduler/EventLoop.h"
-#include "scheduler/ScheduledTask.h"
 #include <vector>
 #include <iostream>
 
@@ -16,21 +15,13 @@ int main() {
     // schedule tasks for existing events
     auto farFuture = std::chrono::system_clock::now() + std::chrono::hours(24 * 365);
     auto events = model.getEvents(-1, farFuture);
-    for (const auto &ev : events) {
-        auto task = std::make_shared<ScheduledTask>(
-            ev.getId(), ev.getDescription(), ev.getTitle(), ev.getTime(), ev.getDuration(),
-            std::chrono::minutes(10),
-            [id = ev.getId(), title = ev.getTitle()](){
-                std::cout << "[" << id << "] \"" << title << "\" notification\n";
-            },
-            [id = ev.getId(), title = ev.getTitle()](){
-                std::cout << "[" << id << "] \"" << title << "\" executing\n";
-            });
-        loop.addTask(task);
-    }
-
     TextualView view(model);
     Controller controller(model, view, &loop);
+    for (const auto &ev : events) {
+        controller.scheduleTask(ev);
+    }
+
+    // run interactive CLI
     controller.run();
     loop.stop();
     return 0;

--- a/scheduler/ScheduledTask.h
+++ b/scheduler/ScheduledTask.h
@@ -11,6 +11,21 @@ class ScheduledTask : public Event {
     bool notified_ = false;
 
 public:
+    // Specify an absolute notification time
+    ScheduledTask(const std::string &id,
+                  const std::string &desc,
+                  const std::string &title,
+                  std::chrono::system_clock::time_point time,
+                  std::chrono::system_clock::duration dur,
+                  std::chrono::system_clock::time_point notifyTime,
+                  std::function<void()> notifyCb,
+                  std::function<void()> actionCb)
+        : Event(id, desc, title, time, dur),
+          notifyCb_(std::move(notifyCb)),
+          actionCb_(std::move(actionCb)),
+          notifyTime_(notifyTime) {}
+
+    // Convenience constructor: notify a duration before execution
     ScheduledTask(const std::string &id,
                   const std::string &desc,
                   const std::string &title,
@@ -19,11 +34,10 @@ public:
                   std::chrono::system_clock::duration notifyBefore,
                   std::function<void()> notifyCb,
                   std::function<void()> actionCb)
-        : Event(id, desc, title, time, dur),
-          notifyCb_(std::move(notifyCb)),
-          actionCb_(std::move(actionCb)) {
-        notifyTime_ = timeUtc - notifyBefore;
-    }
+        : ScheduledTask(id, desc, title, time, dur,
+                        time - notifyBefore,
+                        std::move(notifyCb),
+                        std::move(actionCb)) {}
 
     std::unique_ptr<Event> clone() const override { return std::make_unique<ScheduledTask>(*this); }
 

--- a/tests/events/event_tests.cpp
+++ b/tests/events/event_tests.cpp
@@ -6,6 +6,7 @@
 #include "../../model/recurrence/DailyRecurrence.h"
 #include "../../model/recurrence/WeeklyRecurrence.h"
 #include "../../utils/WeekDay.h"
+#include "../../scheduler/ScheduledTask.h"
 #include "../test_utils.h"
 #include <memory>
 
@@ -39,10 +40,22 @@ static void testRecurringEventDelegation()
     assert(nxt.size() == 1 && nxt[0] == makeTime(2030,1,1,8));
 }
 
+static void testScheduledTaskCustomTimes()
+{
+    auto exec = makeTime(2025,6,1,10);
+    auto notify = exec - minutes(5);
+    ScheduledTask t("X","d","t", exec, hours(1), notify,
+                    [](){}, [](){});
+    assert(t.getNotifyTime() == notify);
+    ScheduledTask t2("Y","d","t", exec, hours(1), minutes(15), [](){}, [](){});
+    assert(t2.getNotifyTime() == exec - minutes(15));
+}
+
 int main()
 {
     testOneTimeEvent();
     testRecurringEventDelegation();
+    testScheduledTaskCustomTimes();
     cout << "Event tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- enhance `ScheduledTask` with absolute notification time constructor
- expose notification timing and callback overrides via `Controller::scheduleTask`
- use new helper in `main_mvc.cpp`
- document how to customise notifications and actions
- test scheduled task timing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68464b73239c832aae77400806decbd9