### PR TITLE
Add configurable multi-notification support

### DIFF
--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -62,8 +62,8 @@ private:
     void printNextEvent();
 
     void scheduleTask(const Event &e,
-                      std::chrono::system_clock::duration notifyBefore =
-                          std::chrono::minutes(10),
+                      std::vector<std::chrono::system_clock::duration> notifyBefore =
+                          {std::chrono::minutes(10)},
                       std::function<void()> notifyCb = {},
                       std::function<void()> actionCb = {});
 

--- a/tests/events/event_tests.cpp
+++ b/tests/events/event_tests.cpp
@@ -44,11 +44,16 @@ static void testScheduledTaskCustomTimes()
 {
     auto exec = makeTime(2025,6,1,10);
     auto notify = exec - minutes(5);
-    ScheduledTask t("X","d","t", exec, hours(1), notify,
+    ScheduledTask t("X","d","t", exec, hours(1), std::vector<std::chrono::system_clock::time_point>{notify},
                     [](){}, [](){});
-    assert(t.getNotifyTime() == notify);
-    ScheduledTask t2("Y","d","t", exec, hours(1), minutes(15), [](){}, [](){});
-    assert(t2.getNotifyTime() == exec - minutes(15));
+    assert(t.getNextNotifyTime() == notify);
+    ScheduledTask t2("Y","d","t", exec, hours(1), std::vector<std::chrono::system_clock::duration>{minutes(15)}, [](){}, [](){});
+    assert(t2.getNextNotifyTime() == exec - minutes(15));
+
+    ScheduledTask tmulti("Z","d","t", exec, hours(1), std::vector<std::chrono::system_clock::duration>{hours(1), minutes(30)}, [](){}, [](){});
+    assert(tmulti.getNextNotifyTime() == exec - hours(1));
+    tmulti.markNotificationSent();
+    assert(tmulti.getNextNotifyTime() == exec - minutes(30));
 }
 
 int main()


### PR DESCRIPTION
## Summary
- allow CLI users to provide multiple notification lead times
- skip notifications for events scheduled within 10 minutes
- extend `ScheduledTask` to support multiple notification times
- update `EventLoop` to handle new notification logic
- add tests for new `ScheduledTask` behaviour

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68465f3c14ec832aa4aa6a49f07c624b