### PR TITLE
Fix race condition when adding tasks

### DIFF
--- a/scheduler/EventLoop.cpp
+++ b/scheduler/EventLoop.cpp
@@ -24,10 +24,10 @@ void EventLoop::stop() {
 void EventLoop::addTask(const std::shared_ptr<ScheduledTask> &task) {
     {
         std::lock_guard<std::mutex> lock(mtx_);
+        model_.addEvent(*task);
         queue_.push(task);
     }
     cv_.notify_one();
-    model_.addEvent(*task);
 }
 
 void EventLoop::threadFunc() {


### PR DESCRIPTION
## Summary
- ensure `EventLoop::addTask` updates the model before scheduling the task

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846e1c2faf4832a9fa63e4384f7ad04