### PR TITLE
Add optional preload horizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ loads all events from this database, reconstructing recurring patterns so
 commands like `list` and `nextn` work across restarts. The database tests in
 `tests/database` verify this behavior.
 
+### Preload Horizon
+
+`Model` can optionally limit how far ahead to preload events from the database.
+Pass a number of days as the second constructor argument. A negative value (the
+default) loads every stored event:
+
+```cpp
+// Only load events occurring in the next 30 days
+SQLiteScheduleDatabase db("events.db");
+Model m(&db, 30);
+```
+
 ## Event Loop
 
 The scheduler now includes an active `EventLoop` component. Tasks derived from

--- a/model/Model.h
+++ b/model/Model.h
@@ -20,6 +20,7 @@ private:
     std::multimap<std::chrono::system_clock::time_point, std::unique_ptr<Event>> events;
     IScheduleDatabase *db_;
     mutable std::mutex mutex_;
+    std::chrono::system_clock::time_point preloadEnd_;
 
     // Check if an event ID already exists in the current list
     bool eventExists(const std::string &id) const;
@@ -27,7 +28,8 @@ private:
 
 public:
     // Construct with an initial list of events and optional database.
-    explicit Model(IScheduleDatabase *db = nullptr);
+    explicit Model(IScheduleDatabase *db = nullptr,
+                   int preloadDaysAhead = -1);
 
     // ReadOnlyModel overrides (note the const):
     std::vector<Event>


### PR DESCRIPTION
## Summary
- allow Model to limit how far ahead to preload events from the database
- document the preload horizon feature in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6846e3a49410832a92f605316694db3f