### PR TITLE
Fix race condition when adding tasks

### DIFF
--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -31,27 +31,6 @@ Controller::Controller(Model &model, View &view, EventLoop *loop)
 {
 }
 
-// Convert a UTC time_point to a local timestamp string
-string Controller::formatTimePoint(const system_clock::time_point &tp)
-{
-    return TimeUtils::formatTimePoint(tp);
-}
-
-// Interpret a local timestamp string and convert it to a UTC time_point
-system_clock::time_point Controller::parseTimePoint(const string &timestamp)
-{
-    return TimeUtils::parseTimePoint(timestamp);
-}
-
-system_clock::time_point Controller::parseDate(const string &dateStr)
-{
-    return TimeUtils::parseDate(dateStr);
-}
-
-system_clock::time_point Controller::parseMonth(const string &monthStr)
-{
-    return TimeUtils::parseMonth(monthStr);
-}
 
 void Controller::printNextEvent()
 {
@@ -61,7 +40,7 @@ void Controller::printNextEvent()
         cout << "Next event: ["
              << next.getId() << "] \""
              << next.getTitle() << "\" @ "
-             << formatTimePoint(next.getTime())
+            << TimeUtils::formatTimePoint(next.getTime())
              << "\n";
     }
     catch (const exception &)
@@ -125,7 +104,7 @@ void Controller::run()
         cout << "Enter time (YYYY-MM-DD HH:MM): ";
         string timestr; getline(cin, timestr);
         system_clock::time_point tp;
-        try { tp = parseTimePoint(timestr); }
+        try { tp = TimeUtils::parseTimePoint(timestr); }
         catch(const exception &e) { cout << e.what() << "\n"; return; }
         OneTimeEvent e{id, desc, title, tp, hours(1)};
         model_.addEvent(e);
@@ -139,7 +118,7 @@ void Controller::run()
         cout << "Enter description: "; getline(cin, desc);
         cout << "Enter start time (YYYY-MM-DD HH:MM): "; getline(cin, timestr);
         system_clock::time_point start;
-        try { start = parseTimePoint(timestr); }
+        try { start = TimeUtils::parseTimePoint(timestr); }
         catch(const exception &e) { cout << e.what() << "\n"; return; }
         cout << "Recurrence type (daily/weekly): "; getline(cin, rtype);
         shared_ptr<RecurrencePattern> pat;
@@ -167,7 +146,7 @@ void Controller::run()
         cout << "Enter description: "; getline(cin, desc);
         cout << "Enter time (YYYY-MM-DD HH:MM): "; getline(cin, timestr);
         system_clock::time_point tp;
-        try { tp = parseTimePoint(timestr); } catch(const exception &e) {
+        try { tp = TimeUtils::parseTimePoint(timestr); } catch(const exception &e) {
             cout << e.what() << "\n"; return; }
         auto notifiers = NotificationRegistry::availableNotifiers();
         if(notifiers.empty()) {
@@ -232,7 +211,7 @@ void Controller::run()
         cout << "Enter date (YYYY-MM-DD): ";
         string d; getline(cin, d);
         system_clock::time_point day;
-        try { day = parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
+        try { day = TimeUtils::parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
         int n = model_.removeEventsOnDay(day);
         cout << "Removed " << n << " events.\n";
     };
@@ -241,7 +220,7 @@ void Controller::run()
         cout << "Enter date within week (YYYY-MM-DD): ";
         string d; getline(cin, d);
         system_clock::time_point day;
-        try { day = parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
+        try { day = TimeUtils::parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
         int n = model_.removeEventsInWeek(day);
         cout << "Removed " << n << " events.\n";
     };
@@ -250,7 +229,7 @@ void Controller::run()
         cout << "Enter time (YYYY-MM-DD HH:MM): ";
         string ts; getline(cin, ts);
         system_clock::time_point tp;
-        try { tp = parseTimePoint(ts); } catch(const exception &e) { cout << e.what() << "\n"; return; }
+        try { tp = TimeUtils::parseTimePoint(ts); } catch(const exception &e) { cout << e.what() << "\n"; return; }
         int n = model_.removeEventsBefore(tp);
         cout << "Removed " << n << " events.\n";
     };
@@ -267,7 +246,7 @@ void Controller::run()
         cout << "Enter date (YYYY-MM-DD): ";
         string d; getline(cin, d);
         system_clock::time_point day;
-        try { day = parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
+        try { day = TimeUtils::parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
         auto evs = model_.getEventsOnDay(day);
         view_.renderEvents(evs);
     };
@@ -276,7 +255,7 @@ void Controller::run()
         cout << "Enter date within week (YYYY-MM-DD): ";
         string d; getline(cin, d);
         system_clock::time_point day;
-        try { day = parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
+        try { day = TimeUtils::parseDate(d); } catch(const exception &e) { cout << e.what() << "\n"; return; }
         auto evs = model_.getEventsInWeek(day);
         view_.renderEvents(evs);
     };
@@ -285,7 +264,7 @@ void Controller::run()
         cout << "Enter month (YYYY-MM): ";
         string m; getline(cin, m);
         system_clock::time_point mo;
-        try { mo = parseMonth(m); } catch(const exception &e) { cout << e.what() << "\n"; return; }
+        try { mo = TimeUtils::parseMonth(m); } catch(const exception &e) { cout << e.what() << "\n"; return; }
         auto evs = model_.getEventsInMonth(mo);
         view_.renderEvents(evs);
     };

--- a/controller/Controller.h
+++ b/controller/Controller.h
@@ -45,18 +45,7 @@ private:
     View &view_;
     EventLoop *loop_;
 
-    // Convert a UTC time_point to a local time string "YYYY-MM-DD HH:MM".
-    static std::string formatTimePoint(const std::chrono::system_clock::time_point &tp);
-
-    // Parse a local time string "YYYY-MM-DD HH:MM" and return a UTC time_point.
-    static std::chrono::system_clock::time_point
-    parseTimePoint(const std::string &timestamp);
-
-    static std::chrono::system_clock::time_point
-    parseDate(const std::string &dateStr);
-
-    static std::chrono::system_clock::time_point
-    parseMonth(const std::string &monthStr);
+    // Time parsing/formatting utilities now live in utils/TimeUtils.h
 
     // Print the next upcoming event or “no upcoming events”.
     void printNextEvent();

--- a/scheduler/EventLoop.cpp
+++ b/scheduler/EventLoop.cpp
@@ -24,10 +24,10 @@ void EventLoop::stop() {
 void EventLoop::addTask(const std::shared_ptr<ScheduledTask> &task) {
     {
         std::lock_guard<std::mutex> lock(mtx_);
+        model_.addEvent(*task);
         queue_.push(task);
     }
     cv_.notify_one();
-    model_.addEvent(*task);
 }
 
 void EventLoop::threadFunc() {

--- a/tests/controller/controller_tests.cpp
+++ b/tests/controller/controller_tests.cpp
@@ -11,18 +11,19 @@
 #define private public
 #include "../../controller/Controller.h"
 #undef private
+#include "../../utils/TimeUtils.h"
 
 using namespace std;
 using namespace chrono;
 
 static void testControllerParseFormat()
 {
-    auto tp = Controller::parseTimePoint("2025-06-01 09:30");
-    string s = Controller::formatTimePoint(tp);
+    auto tp = TimeUtils::parseTimePoint("2025-06-01 09:30");
+    string s = TimeUtils::formatTimePoint(tp);
     assert(s == "2025-06-01 09:30");
 
     bool threw = false;
-    try { Controller::parseTimePoint("bad format"); }
+    try { TimeUtils::parseTimePoint("bad format"); }
     catch(const exception&) { threw = true; }
     assert(threw);
 
@@ -31,8 +32,8 @@ static void testControllerParseFormat()
     bool hadPrev = prevPtr != nullptr;
     setenv("TZ", "Europe/Berlin", 1);
     tzset();
-    auto tp2 = Controller::parseTimePoint("2025-06-05 12:00");
-    string s2 = Controller::formatTimePoint(tp2);
+    auto tp2 = TimeUtils::parseTimePoint("2025-06-05 12:00");
+    string s2 = TimeUtils::formatTimePoint(tp2);
     assert(s2 == "2025-06-05 12:00");
     if (hadPrev)
         setenv("TZ", prev.c_str(), 1);
@@ -58,8 +59,8 @@ static void testControllerParseFormatTimeZones()
         setenv("TZ", c.zone, 1);
         tzset();
 
-        auto tp = Controller::parseTimePoint("2025-06-05 12:00");
-        string round = Controller::formatTimePoint(tp);
+        auto tp = TimeUtils::parseTimePoint("2025-06-05 12:00");
+        string round = TimeUtils::formatTimePoint(tp);
         assert(round == "2025-06-05 12:00");
 
         time_t t = system_clock::to_time_t(tp);
@@ -87,37 +88,37 @@ static void testControllerCrossTimeZones()
     // Event created in Chicago during DST
     setenv("TZ", "America/Chicago", 1);
     tzset();
-    auto tpSummer = Controller::parseTimePoint("2025-06-01 14:00");
+    auto tpSummer = TimeUtils::parseTimePoint("2025-06-01 14:00");
 
     // View the event from different locations
-    string chicago = Controller::formatTimePoint(tpSummer);
+    string chicago = TimeUtils::formatTimePoint(tpSummer);
     assert(chicago == "2025-06-01 14:00");
 
     setenv("TZ", "Europe/London", 1);
     tzset();
-    string london = Controller::formatTimePoint(tpSummer);
+    string london = TimeUtils::formatTimePoint(tpSummer);
     assert(london == "2025-06-01 20:00");
 
     setenv("TZ", "Asia/Tokyo", 1);
     tzset();
-    string tokyo = Controller::formatTimePoint(tpSummer);
+    string tokyo = TimeUtils::formatTimePoint(tpSummer);
     assert(tokyo == "2025-06-02 04:00");
 
     // Event created in Chicago outside of DST
     setenv("TZ", "America/Chicago", 1);
     tzset();
-    auto tpWinter = Controller::parseTimePoint("2025-01-15 14:00");
-    string chicagoW = Controller::formatTimePoint(tpWinter);
+    auto tpWinter = TimeUtils::parseTimePoint("2025-01-15 14:00");
+    string chicagoW = TimeUtils::formatTimePoint(tpWinter);
     assert(chicagoW == "2025-01-15 14:00");
 
     setenv("TZ", "Europe/London", 1);
     tzset();
-    string londonW = Controller::formatTimePoint(tpWinter);
+    string londonW = TimeUtils::formatTimePoint(tpWinter);
     assert(londonW == "2025-01-15 20:00");
 
     setenv("TZ", "Asia/Tokyo", 1);
     tzset();
-    string tokyoW = Controller::formatTimePoint(tpWinter);
+    string tokyoW = TimeUtils::formatTimePoint(tpWinter);
     assert(tokyoW == "2025-01-16 05:00");
 
     if (hadPrev)

--- a/view/TextualView.cpp
+++ b/view/TextualView.cpp
@@ -1,5 +1,6 @@
 #include "TextualView.h"
 #include <iomanip>
+#include "../utils/TimeUtils.h"
 
 TextualView::TextualView(const ReadOnlyModel &model)
     : View(model)
@@ -27,18 +28,10 @@ void TextualView::renderEvents(const std::vector<Event> &events)
     for (const auto &e : events)
     {
         auto tp = e.getTime();
-        std::time_t t_c = std::chrono::system_clock::to_time_t(tp);
-        std::tm tm_buf;
-#if defined(_MSC_VER)
-        localtime_s(&tm_buf, &t_c);
-#else
-        localtime_r(&t_c, &tm_buf);
-#endif
-        char buf[32];
-        strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &tm_buf);
+        std::string ts = TimeUtils::formatTimePoint(tp);
 
         std::cout << "[" << e.getId() << "] \""
-                  << e.getTitle() << "\" @ " << buf;
+                  << e.getTitle() << "\" @ " << ts;
         if (e.isRecurring())
             std::cout << " (recurring)";
         std::cout << "\n";


### PR DESCRIPTION
## Summary
- ensure `EventLoop::addTask` updates the model before scheduling the task
- centralize time helpers in `TimeUtils`
- update TextualView and tests to use common utilities

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846e1c2faf4832a9fa63e4384f7ad04