### PR TITLE
Add integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,24 @@ BUILTIN_NOTIFIERS_TEST_SRCS = tests/utils/builtin_notifiers_tests.cpp
 BUILTIN_NOTIFIERS_TEST_OBJS = $(BUILTIN_NOTIFIERS_TEST_SRCS:.cpp=.o)
 BUILTIN_NOTIFIERS_TEST_TARGET = builtin_notifiers_tests
 
-TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET) $(VIEW_TEST_TARGET) $(API_TEST_TARGET) $(DATABASE_TEST_TARGET) $(ACTION_REGISTRY_TEST_TARGET) $(BUILTIN_ACTIONS_TEST_TARGET) $(NOTIFICATION_REGISTRY_TEST_TARGET) $(BUILTIN_NOTIFIERS_TEST_TARGET)
+# Integration tests combining CLI, API and database
+INTEGRATION_TEST_SRCS = tests/integration/integration_tests.cpp \
+                       controller/Controller.cpp \
+                       view/TextualView.cpp \
+                       api/ApiServer.cpp \
+                       model/Model.cpp \
+                       model/OneTimeEvent.cpp \
+                       model/RecurringEvent.cpp \
+                       model/recurrence/DailyRecurrence.cpp \
+                       model/recurrence/WeeklyRecurrence.cpp \
+                       model/recurrence/MonthlyRecurrence.cpp \
+                       model/recurrence/YearlyRecurrence.cpp \
+                       database/SQLiteScheduleDatabase.cpp \
+                       scheduler/EventLoop.cpp
+INTEGRATION_TEST_OBJS = $(INTEGRATION_TEST_SRCS:.cpp=.o)
+INTEGRATION_TEST_TARGET = integration_tests
+
+TEST_TARGETS = $(RECURRENCE_TEST_TARGET) $(EVENT_TEST_TARGET) $(MODEL_TEST_TARGET) $(MODEL_COMPREHENSIVE_TEST_TARGET) $(CONTROLLER_TEST_TARGET) $(VIEW_TEST_TARGET) $(API_TEST_TARGET) $(DATABASE_TEST_TARGET) $(ACTION_REGISTRY_TEST_TARGET) $(BUILTIN_ACTIONS_TEST_TARGET) $(NOTIFICATION_REGISTRY_TEST_TARGET) $(BUILTIN_NOTIFIERS_TEST_TARGET) $(INTEGRATION_TEST_TARGET)
 
 test: $(TEST_TARGETS)
 	./run_all_tests.sh
@@ -202,5 +219,8 @@ $(NOTIFICATION_REGISTRY_TEST_TARGET): $(NOTIFICATION_REGISTRY_TEST_OBJS)
 
 $(BUILTIN_NOTIFIERS_TEST_TARGET): $(BUILTIN_NOTIFIERS_TEST_OBJS)
 	$(CXX) $(CXXFLAGS) $(BUILTIN_NOTIFIERS_TEST_OBJS) -o $@
+	
+$(INTEGRATION_TEST_TARGET): $(INTEGRATION_TEST_OBJS)
+	$(CXX) $(CXXFLAGS) $(INTEGRATION_TEST_OBJS) -lsqlite3 -pthread -o $@
 
 .PHONY: test

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 # Build all test executables
-make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests action_registry_tests builtin_actions_tests notification_registry_tests builtin_notifiers_tests
+make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests action_registry_tests builtin_actions_tests notification_registry_tests builtin_notifiers_tests integration_tests
 
 # Run each test executable sequentially
-for t in recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests action_registry_tests builtin_actions_tests notification_registry_tests builtin_notifiers_tests; do
+for t in recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests action_registry_tests builtin_actions_tests notification_registry_tests builtin_notifiers_tests integration_tests; do
     echo "Running $t"
     ./$t
     echo

--- a/tests/integration/integration_tests.cpp
+++ b/tests/integration/integration_tests.cpp
@@ -1,0 +1,66 @@
+#include <cassert>
+#include <thread>
+#include <cstdio>
+#include "../../api/ApiServer.h"
+#include "../../controller/Controller.h"
+#include "../../view/TextualView.h"
+#include "../../database/SQLiteScheduleDatabase.h"
+#include "../../model/Model.h"
+#include "../../external/json/nlohmann/json.hpp"
+#include "../../api/httplib.h"
+
+using json = nlohmann::json;
+using namespace std;
+using namespace chrono;
+
+static void runServer(ApiServer &srv) {
+    srv.start();
+}
+
+int main() {
+    const char *path = "integration_test.db";
+    std::remove(path);
+
+    SQLiteScheduleDatabase db(path);
+    Model model(&db);
+    TextualView view(model);
+    Controller controller(model, view);
+    ApiServer srv(model, 8099);
+    thread th(runServer, std::ref(srv));
+    this_thread::sleep_for(milliseconds(100));
+
+    // simulate CLI input to add one event
+    string input = "addat\nTitle1\nDesc1\n2025-06-05 12:30\nquit\n";
+    istringstream iss(input);
+    auto *cinBuf = cin.rdbuf();
+    cin.rdbuf(iss.rdbuf());
+    controller.run();
+    cin.rdbuf(cinBuf);
+
+    httplib::Client cli("localhost", 8099);
+    auto res = cli.Get("/events");
+    assert(res && res->status == 200);
+    json j = json::parse(res->body);
+    assert(j["status"] == "ok");
+    assert(j["data"].size() == 1);
+    string id = j["data"][0]["id"];
+    assert(j["data"][0]["title"] == "Title1");
+    assert(j["data"][0]["description"] == "Desc1");
+    assert(j["data"][0]["time"] == "2025-06-05 12:30");
+
+    auto res2 = cli.Delete( ("/events/" + id).c_str() );
+    assert(res2 && res2->status == 200);
+    json j2 = json::parse(res2->body);
+    assert(j2["status"] == "ok");
+
+    auto res3 = cli.Get("/events");
+    assert(res3 && res3->status == 200);
+    json j3 = json::parse(res3->body);
+    assert(j3["data"].size() == 0);
+
+    srv.stop();
+    th.join();
+    std::remove(path);
+    cout << "Integration tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend Makefile and test runner to build `integration_tests`
- create integration test exercising CLI and API with a temporary SQLite database

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846e8d2ded4832a8e44101f3e9031a7