### PR TITLE
Fix timezone handling in tests

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
+
+# Use a fixed timezone so results are deterministic across environments
+export TZ=UTC
+
 # Build all test executables
 make recurrence_tests event_tests model_tests model_comprehensive_tests controller_tests view_tests api_tests database_tests action_registry_tests builtin_actions_tests notification_registry_tests builtin_notifiers_tests integration_tests
 

--- a/tests/model/model_tests.cpp
+++ b/tests/model/model_tests.cpp
@@ -248,6 +248,42 @@ static void testEventsTimeZones()
     tzset();
 }
 
+static void testEventsChicagoTimeZone()
+{
+    const char *prevPtr = getenv("TZ");
+    std::string prev = prevPtr ? std::string(prevPtr) : std::string();
+    bool hadPrev = prevPtr != nullptr;
+
+    setenv("TZ", "America/Chicago", 1);
+    tzset();
+
+    Model m({});
+    using TimeUtils::parseTimePoint;
+    using TimeUtils::parseDate;
+
+    auto evTime = parseTimePoint("2025-06-01 00:30");
+    OneTimeEvent e("1","d","t", evTime, hours(1));
+    m.addEvent(e);
+
+    auto queryDay = parseDate("2025-06-01");
+    auto d = m.getEventsOnDay(queryDay);
+    assert(d.size() == 1);
+    auto w = m.getEventsInWeek(queryDay);
+    assert(w.size() == 1);
+    auto mo = m.getEventsInMonth(queryDay);
+    assert(mo.size() == 1);
+
+    auto prevDay = parseDate("2025-05-31");
+    auto prevList = m.getEventsOnDay(prevDay);
+    assert(prevList.empty());
+
+    if (hadPrev)
+        setenv("TZ", prev.c_str(), 1);
+    else
+        unsetenv("TZ");
+    tzset();
+}
+
 int main()
 {
     testModelAddAndRetrieve();
@@ -264,6 +300,7 @@ int main()
     testEventsInWeek();
     testEventsInMonth();
     testEventsTimeZones();
+    testEventsChicagoTimeZone();
     cout << "Model tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- make tests timezone-independent by exporting `TZ=UTC`
- add a new Chicago timezone test case

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846f2820a00832a9ebce5e29c4b8ceb