### PR TITLE
Sync Google Calendar event IDs for deletion

### DIFF
--- a/calendar/GoogleCalendarApi.cpp
+++ b/calendar/GoogleCalendarApi.cpp
@@ -28,6 +28,7 @@ void GoogleCalendarApi::addEvent(const Event &e) {
     setEnv("GCAL_CALENDAR_ID", calendarId_);
     setEnv("GCAL_TITLE", e.getTitle());
     setEnv("GCAL_DESC", e.getDescription());
+    setEnv("GCAL_EVENT_ID", e.getId());
     auto start = TimeUtils::formatRFC3339UTC(e.getTime());
     auto end = TimeUtils::formatRFC3339UTC(e.getTime() + e.getDuration());
     setEnv("GCAL_START", start);
@@ -38,6 +39,7 @@ void GoogleCalendarApi::addEvent(const Event &e) {
     unsetEnv("GCAL_CALENDAR_ID");
     unsetEnv("GCAL_TITLE");
     unsetEnv("GCAL_DESC");
+    unsetEnv("GCAL_EVENT_ID");
     unsetEnv("GCAL_START");
     unsetEnv("GCAL_END");
 }

--- a/calendar_integration/calendar_service.py
+++ b/calendar_integration/calendar_service.py
@@ -10,6 +10,7 @@ class Event:
     end: str    # RFC3339 timestamp
     description: str = ""
     timezone: str = "UTC"
+    id: str | None = None
 
 class CalendarService(ABC):
     """Abstract calendar service interface."""

--- a/calendar_integration/gcal_service.py
+++ b/calendar_integration/gcal_service.py
@@ -18,7 +18,8 @@ def main():
         start = os.environ["GCAL_START"]
         end = os.environ["GCAL_END"]
         desc = os.environ.get("GCAL_DESC", "")
-        event = Event(summary=title, start=start, end=end, description=desc)
+        event_id = os.environ.get("GCAL_EVENT_ID")
+        event = Event(summary=title, start=start, end=end, description=desc, id=event_id)
         service.add_event(event)
     elif action == "delete":
         event_id = os.environ["GCAL_EVENT_ID"]

--- a/calendar_integration/google_calendar_service.py
+++ b/calendar_integration/google_calendar_service.py
@@ -24,6 +24,9 @@ class GoogleCalendarService(CalendarService):
             "start": {"dateTime": event.start, "timeZone": event.timezone},
             "end": {"dateTime": event.end, "timeZone": event.timezone},
         }
+        if event.id:
+            body["id"] = event.id
+
         created = (
             self.service.events()
             .insert(calendarId=self.calendar_id, body=body)


### PR DESCRIPTION
## Summary
- ensure `GCAL_EVENT_ID` is sent on add
- allow Python helper to accept an optional event ID
- push the ID through to Google Calendar so we can delete by the same ID

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684711df7c28832a8b180e37a265b4f5