### PR TITLE
Fix recurring events visibility in date queries

### DIFF
--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -285,12 +285,36 @@ std::vector<Event> Model::getEventsOnDay(std::chrono::system_clock::time_point d
     for (const auto &kv : events)
     {
         const Event &e = *kv.second;
-        if (e.getTime() < start)
-            continue;
-        if (e.getTime() >= end)
-            break;
-        result.push_back(e);
+        if (!e.isRecurring())
+        {
+            if (e.getTime() < start)
+                continue;
+            if (e.getTime() >= end)
+                break;
+            result.push_back(e);
+        }
+        else
+        {
+            const auto *re = dynamic_cast<const RecurringEvent *>(kv.second.get());
+            if (!re)
+                continue;
+            auto times = re->getNextNOccurrences(start - std::chrono::seconds(1), 1000);
+            for (auto t : times)
+            {
+                if (t >= end)
+                    break;
+                if (t >= start)
+                {
+                    RecurringEvent occ(re->getId(), re->getDescription(), re->getTitle(),
+                                       t, re->getDuration(), re->getRecurrencePattern(),
+                                       re->getCategory());
+                    result.push_back(occ);
+                }
+            }
+        }
     }
+    std::sort(result.begin(), result.end(),
+              [](const Event &a, const Event &b) { return a.getTime() < b.getTime(); });
     return result;
 }
 
@@ -312,12 +336,36 @@ std::vector<Event> Model::getEventsInWeek(std::chrono::system_clock::time_point 
     for (const auto &kv : events)
     {
         const Event &e = *kv.second;
-        if (e.getTime() < start)
-            continue;
-        if (e.getTime() >= end)
-            break;
-        result.push_back(e);
+        if (!e.isRecurring())
+        {
+            if (e.getTime() < start)
+                continue;
+            if (e.getTime() >= end)
+                break;
+            result.push_back(e);
+        }
+        else
+        {
+            const auto *re = dynamic_cast<const RecurringEvent *>(kv.second.get());
+            if (!re)
+                continue;
+            auto times = re->getNextNOccurrences(start - std::chrono::seconds(1), 1000);
+            for (auto t : times)
+            {
+                if (t >= end)
+                    break;
+                if (t >= start)
+                {
+                    RecurringEvent occ(re->getId(), re->getDescription(), re->getTitle(),
+                                       t, re->getDuration(), re->getRecurrencePattern(),
+                                       re->getCategory());
+                    result.push_back(occ);
+                }
+            }
+        }
     }
+    std::sort(result.begin(), result.end(),
+              [](const Event &a, const Event &b) { return a.getTime() < b.getTime(); });
     return result;
 }
 
@@ -353,12 +401,36 @@ std::vector<Event> Model::getEventsInMonth(std::chrono::system_clock::time_point
     for (const auto &kv : events)
     {
         const Event &e = *kv.second;
-        if (e.getTime() < start)
-            continue;
-        if (e.getTime() >= end)
-            break;
-        result.push_back(e);
+        if (!e.isRecurring())
+        {
+            if (e.getTime() < start)
+                continue;
+            if (e.getTime() >= end)
+                break;
+            result.push_back(e);
+        }
+        else
+        {
+            const auto *re = dynamic_cast<const RecurringEvent *>(kv.second.get());
+            if (!re)
+                continue;
+            auto times = re->getNextNOccurrences(start - std::chrono::seconds(1), 1000);
+            for (auto t : times)
+            {
+                if (t >= end)
+                    break;
+                if (t >= start)
+                {
+                    RecurringEvent occ(re->getId(), re->getDescription(), re->getTitle(),
+                                       t, re->getDuration(), re->getRecurrencePattern(),
+                                       re->getCategory());
+                    result.push_back(occ);
+                }
+            }
+        }
     }
+    std::sort(result.begin(), result.end(),
+              [](const Event &a, const Event &b) { return a.getTime() < b.getTime(); });
     return result;
 }
 

--- a/tests/model/model_tests.cpp
+++ b/tests/model/model_tests.cpp
@@ -210,6 +210,29 @@ static void testEventsInMonth()
     assert(evs[1].getId() == "3");
 }
 
+static void testRecurringInDayWeekMonth()
+{
+    Model m;
+    auto start = makeTime(2025,6,1,9);
+    auto pat = std::make_shared<DailyRecurrence>(start, 1);
+    RecurringEvent r("R","d","t", start, hours(1), pat);
+    OneTimeEvent o("O","d","t", makeTime(2025,6,3,10), hours(1));
+    m.addEvent(r);
+    m.addEvent(o);
+
+    auto day = makeTime(2025,6,3,0);
+    auto d = m.getEventsOnDay(day);
+    assert(d.size() == 2);
+    assert(d[0].getId() == "R");
+    assert(d[1].getId() == "O");
+
+    auto w = m.getEventsInWeek(day);
+    assert(w.size() == 8); // 7 occurrences + 1 one-time
+
+    auto mo = m.getEventsInMonth(day);
+    assert(mo.size() == 31); // 30 daily occurrences + 1 one-time
+}
+
 static void testEventsTimeZones()
 {
     const char *prevPtr = getenv("TZ");
@@ -299,6 +322,7 @@ int main()
     testEventsOnDay();
     testEventsInWeek();
     testEventsInMonth();
+    testRecurringInDayWeekMonth();
     testEventsTimeZones();
     testEventsChicagoTimeZone();
     cout << "Model tests passed\n";


### PR DESCRIPTION
## Summary
- expand recurring events in `getEventsOnDay`, `getEventsInWeek`, and `getEventsInMonth`
- add regression test ensuring recurring events appear in day/week/month views

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f7d0d29f8832a842534b0d61eb122