### PR TITLE
Add Google Tasks support

### DIFF
--- a/calendar/GoogleCalendarApi.h
+++ b/calendar/GoogleCalendarApi.h
@@ -40,6 +40,8 @@ private:
     // Convert Event recurrence pattern to Google Calendar RRULE
     std::string convertRecurrence(const Event &event) const;
 
+    bool isTask(const Event &event) const;
+
 public:
     GoogleCalendarApi(const std::string &credentials_file,
                       const std::string &calendar_id = "primary",

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -193,7 +193,7 @@ void Controller::run()
 
         string id = model_.generateUniqueId();
         auto notifyCb = [note,id,title](){ note(id,title); };
-        OneTimeEvent e{id, desc, title, tp, hours(1)};
+        OneTimeEvent e{id, desc, title, tp, std::chrono::seconds(0), "task"};
         scheduleTask(e, leadTimes, notifyCb, act);
         cout << "Added task [" << id << "]\n";
     };


### PR DESCRIPTION
## Summary
- integrate Google Tasks API in the helper script
- detect `task` category events and map them to Google Tasks
- update the `addtask` CLI command to create zero-duration tasks

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686561eb9b74832aa04be7bafaf9d1d2