### PR TITLE
Implement task API routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SRCS = main.cpp \
        api/routes/AvailabilityRoutes.cpp \
        api/routes/StatsRoutes.cpp \
        api/routes/RecurringRoutes.cpp \
+       api/routes/TaskRoutes.cpp \
        database/SQLiteScheduleDatabase.cpp \
        scheduler/EventLoop.cpp \
        calendar/GoogleCalendarApi.cpp \
@@ -41,7 +42,8 @@ MVC_SRCS = $(filter-out \
              api/routes/EventRoutes.cpp \
              api/routes/AvailabilityRoutes.cpp \
              api/routes/StatsRoutes.cpp \
-             api/routes/RecurringRoutes.cpp, \
+             api/routes/RecurringRoutes.cpp \
+             api/routes/TaskRoutes.cpp, \
            $(SRCS)) \
            main_mvc.cpp
 MVC_OBJS = $(MVC_SRCS:.cpp=.o)
@@ -160,6 +162,8 @@ API_TEST_SRCS = tests/api/api_tests.cpp \
                 api/routes/AvailabilityRoutes.cpp \
                 api/routes/StatsRoutes.cpp \
                 api/routes/RecurringRoutes.cpp \
+                api/routes/TaskRoutes.cpp \
+                scheduler/EventLoop.cpp \
                 utils/EnvLoader.cpp \
                 security/Auth.cpp \
                 security/RateLimiter.cpp \
@@ -226,6 +230,7 @@ INTEGRATION_TEST_SRCS = tests/integration/integration_tests.cpp \
                        api/routes/AvailabilityRoutes.cpp \
                        api/routes/StatsRoutes.cpp \
                        api/routes/RecurringRoutes.cpp \
+                       api/routes/TaskRoutes.cpp \
                        utils/EnvLoader.cpp \
                        security/Auth.cpp \
                        security/RateLimiter.cpp \

--- a/api/ApiServer.h
+++ b/api/ApiServer.h
@@ -4,6 +4,7 @@
 #include "httplib.h"
 #include "../security/Auth.h"
 #include "../security/RateLimiter.h"
+#include "../scheduler/EventLoop.h"
 
 // ApiServer exposes scheduler functionality via HTTP endpoints.
 // All times in requests/responses are local time strings "YYYY-MM-DD HH:MM".
@@ -14,7 +15,10 @@ public:
     // The server binds to `host` and `port`. Security features like
     // authentication and rate limiting are configured via environment
     // variables loaded by `EnvLoader`.
-    ApiServer(Model &model, int port = 8080, const std::string &host = "127.0.0.1");
+    ApiServer(Model &model,
+              int port = 8080,
+              const std::string &host = "127.0.0.1",
+              EventLoop *loop = nullptr);
     void start();
     void stop();
 
@@ -26,6 +30,7 @@ private:
     httplib::Server server_;
     std::unique_ptr<Auth> auth_;
     std::unique_ptr<RateLimiter> limiter_;
+    EventLoop *loop_;
 
     void setupRoutes();
 };

--- a/api/routes/TaskRoutes.cpp
+++ b/api/routes/TaskRoutes.cpp
@@ -1,0 +1,131 @@
+#include "TaskRoutes.h"
+#include "Serialization.h"
+#include "../../utils/TimeUtils.h"
+#include "../../utils/Sanitize.h"
+#include "../../utils/NotificationRegistry.h"
+#include "../../utils/ActionRegistry.h"
+#include "../../scheduler/ScheduledTask.h"
+#include <iostream>
+#include <algorithm>
+
+using namespace std::chrono;
+using ApiSerialization::eventToJson;
+
+namespace TaskRoutes {
+
+static std::chrono::minutes parseDuration(const std::string &t)
+{
+    std::string s = t;
+    s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
+    if (s.empty()) return std::chrono::minutes(0);
+    char suf = s.back();
+    int val;
+    if (suf == 'h' || suf == 'H') {
+        val = std::stoi(s.substr(0, s.size() - 1));
+        return std::chrono::minutes(val * 60);
+    }
+    if (suf == 'm' || suf == 'M') {
+        val = std::stoi(s.substr(0, s.size() - 1));
+        return std::chrono::minutes(val);
+    }
+    val = std::stoi(s);
+    return std::chrono::minutes(val);
+}
+
+void registerRoutes(httplib::Server &server, Model &model, EventLoop *loop) {
+    server.Get("/notifiers", [](const httplib::Request &, httplib::Response &res) {
+        res.set_header("Access-Control-Allow-Origin", "*");
+        nlohmann::json out;
+        try {
+            auto names = NotificationRegistry::availableNotifiers();
+            out["status"] = "ok";
+            out["data"] = names;
+        } catch (const std::exception &) {
+            out = {{"status","error"},{"message","Invalid input"}};
+        }
+        res.set_content(out.dump(), "application/json");
+    });
+
+    server.Get("/actions", [](const httplib::Request &, httplib::Response &res) {
+        res.set_header("Access-Control-Allow-Origin", "*");
+        nlohmann::json out;
+        try {
+            auto names = ActionRegistry::availableActions();
+            out["status"] = "ok";
+            out["data"] = names;
+        } catch (const std::exception &) {
+            out = {{"status","error"},{"message","Invalid input"}};
+        }
+        res.set_content(out.dump(), "application/json");
+    });
+
+    server.Get("/tasks", [&model](const httplib::Request &, httplib::Response &res){
+        res.set_header("Access-Control-Allow-Origin", "*");
+        nlohmann::json out;
+        try {
+            auto horizon = system_clock::now() + hours(24 * 365 * 5);
+            auto events = model.getEvents(-1, horizon);
+            nlohmann::json data = nlohmann::json::array();
+            for (const auto &ev : events) {
+                if (ev.getCategory() == "task")
+                    data.push_back(eventToJson(ev));
+            }
+            out["status"] = "ok";
+            out["data"] = data;
+        } catch (const std::exception &) {
+            out = {{"status","error"},{"message","Invalid input"}};
+        }
+        res.set_content(out.dump(), "application/json");
+    });
+
+    if (loop) {
+        server.Post("/tasks", [loop,&model](const httplib::Request &req, httplib::Response &res){
+            res.set_header("Access-Control-Allow-Origin", "*");
+            nlohmann::json out;
+            try {
+                auto body = nlohmann::json::parse(req.body);
+                std::string title = sanitize(body.value("title", ""));
+                std::string description = sanitize(body.value("description", ""), 500);
+                std::string timeStr = body.at("time");
+                std::string notifierName = body.at("notifier");
+                std::string actionName = body.at("action");
+                auto time = TimeUtils::parseTimePoint(timeStr);
+                std::vector<std::chrono::system_clock::duration> notifyDur;
+                if (body.contains("notify") && body["notify"].is_array()) {
+                    for (const auto &el : body["notify"]) {
+                        notifyDur.push_back(parseDuration(el.get<std::string>()));
+                    }
+                    if (notifyDur.empty()) notifyDur.push_back(std::chrono::minutes(10));
+                } else {
+                    notifyDur.push_back(std::chrono::minutes(10));
+                }
+                auto notifier = NotificationRegistry::getNotifier(notifierName);
+                auto action = ActionRegistry::getAction(actionName);
+                if (!notifier || !action) throw std::runtime_error("invalid callback");
+                std::string id = model.generateUniqueId();
+                auto notifyCb = [notifier,id,title](){ notifier(id,title); };
+                OneTimeEvent e(id, description, title, time, seconds(0), "task");
+                auto now = system_clock::now();
+                std::vector<system_clock::time_point> notifyTimes;
+                if (e.getTime() - now >= std::chrono::minutes(10)) {
+                    for (auto d : notifyDur) {
+                        auto tp = e.getTime() - d;
+                        if (tp > now) notifyTimes.push_back(tp);
+                    }
+                }
+                auto task = std::make_shared<ScheduledTask>(id, description, title,
+                                            e.getTime(), e.getDuration(), notifyTimes,
+                                            notifyCb, action);
+                task->setCategory("task");
+                loop->addTask(task);
+                out["status"] = "ok";
+                out["data"] = eventToJson(e);
+            } catch (const std::exception &) {
+                out = {{"status","error"},{"message","Invalid input"}};
+            }
+            res.set_content(out.dump(), "application/json");
+        });
+    }
+}
+
+} // namespace TaskRoutes

--- a/api/routes/TaskRoutes.h
+++ b/api/routes/TaskRoutes.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "httplib.h"
+#include "../../model/Model.h"
+#include "../../scheduler/EventLoop.h"
+
+namespace TaskRoutes {
+    void registerRoutes(httplib::Server &server, Model &model, EventLoop *loop);
+}

--- a/controller/Controller.cpp
+++ b/controller/Controller.cpp
@@ -330,6 +330,7 @@ void Controller::scheduleTask(const Event &e,
     auto task = std::make_shared<ScheduledTask>(
         e.getId(), e.getDescription(), e.getTitle(), e.getTime(), e.getDuration(),
         notifyTimes, std::move(notifyCb), std::move(actionCb));
+    task->setCategory("task");
     loop_->addTask(task);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,7 +26,7 @@ int main()
     int port = portEnv ? std::stoi(portEnv) : 8080;
     const char *hostEnv = getenv("HOST");
     std::string host = hostEnv ? hostEnv : "127.0.0.1";
-    ApiServer api(model, port, host);
+    ApiServer api(model, port, host, &loop);
     api.start();
 
     loop.stop();


### PR DESCRIPTION
## Summary
- add TaskRoutes for listing notifiers and actions and creating tasks
- expose EventLoop in ApiServer and register builtin callbacks
- update Controller to mark scheduled tasks with category
- adjust build to compile new routes and update tests
- expand API tests to cover task endpoints

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6865db57c1ec832a9f1a1638c613d89a